### PR TITLE
fix:set all-0 instead of empty balance change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 feed.sh
 config-*.yaml
 configs/
+node*.log
+pids

--- a/cmd/feeder_tool.go
+++ b/cmd/feeder_tool.go
@@ -166,7 +166,7 @@ func reloadConfigToFetchNewTokens(remainningFeeders map[string]*feederInfo, newF
 	for length > 0 {
 		conf := feedertypes.ReloadConfig()
 		for tokenRemainning, fInfo := range remainningFeeders {
-			fmt.Printf("loading config for for token %s \r\n", fInfo.params.tokenName)
+			fmt.Printf("loading config for for token %s ...\r\n", fInfo.params.tokenName)
 			for _, token := range conf.Tokens {
 				if strings.EqualFold(token, tokenRemainning) {
 					delete(remainningFeeders, tokenRemainning)
@@ -292,12 +292,14 @@ func feedToken(fInfo *feederInfo, cc *grpc.ClientConn, f *fetcher.Fetcher, conf 
 			}
 			basedBlock := t.height - delta
 
-			if p.Decimal > decimal {
-				p.Price = p.Price[:len(p.Price)-int(p.Decimal-decimal)]
-				p.Decimal = decimal
-			} else if p.Decimal < decimal {
-				p.Price = p.Price + strings.Repeat("0", decimal-p.Decimal)
-				p.Decimal = decimal
+			if !(fInfo.params.tokenName == types.NativeTokenETH) {
+				if p.Decimal > decimal {
+					p.Price = p.Price[:len(p.Price)-int(p.Decimal-decimal)]
+					p.Decimal = decimal
+				} else if p.Decimal < decimal {
+					p.Price = p.Price + strings.Repeat("0", decimal-p.Decimal)
+					p.Decimal = decimal
+				}
 			}
 			log.Printf("submit price=%s decimal=%d of token=%s on height=%d for roundID:%d, feederID:%d", p.Price, p.Decimal, fInfo.params.tokenName, t.height, roundID, feederID)
 			res := exoclient.SendTx(cc, feederID, basedBlock, p.Price, p.RoundID, p.Decimal, int32(delta)+1, t.gas)

--- a/fetcher/beaconchain/beaconchain.go
+++ b/fetcher/beaconchain/beaconchain.go
@@ -103,14 +103,13 @@ var (
 	stakerValidators = map[int]*validatorList{2: {0, validatorsTmp}}
 	// latest finalized epoch we've got balances summarized for stakers
 	finalizedEpoch uint64
-	// latest stakerBalanceChanges
-	latestChangesBytes = make([]byte, 0)
+	// latest stakerBalanceChanges, initialized as 0 change (256-0 of 1st parts means that all stakers have 32 efb)
+	latestChangesBytes = make([]byte, 32)
 
 	// errors
-	errTokenNotSupported         = errors.New("token not supported")
-	errBalanceNotChanged         = errors.New("balance not changed")
-	urlQueryValidatorBalances, _ = url.Parse("https://beaconcha.in/api/v1/validator")
-	queryValue                   = url.Values(map[string][]string{"offset": {"0"}, "limit": {"1"}})
+	errTokenNotSupported = errors.New("token not supported")
+	// urlQueryValidatorBalances, _ = url.Parse("https://beaconcha.in/api/v1/validator")
+	// queryValue                   = url.Values(map[string][]string{"offset": {"0"}, "limit": {"1"}})
 
 	urlQueryHeader          = "eth/v1/beacon/headers"
 	urlQueryHeaderFinalized = "eth/v1/beacon/headers/finalized"
@@ -209,6 +208,7 @@ func ResetStakerValidatorsForAll(stakerInfos []*oracletypes.StakerInfo) {
 	stakerValidators = make(map[int]*validatorList)
 	for _, stakerInfo := range stakerInfos {
 		validators := make([]string, 0, len(stakerInfo.ValidatorPubkeyList))
+
 		for _, validatorPubkey := range stakerInfo.ValidatorPubkeyList {
 			validators = append(validators, validatorPubkey)
 		}
@@ -233,7 +233,6 @@ func Fetch(token string) (*types.PriceInfo, error) {
 		return nil, errTokenNotSupported
 	}
 	// check if finalized epoch had been updated
-	// epoch, err := GetFinalizedEpoch()
 	epoch, stateRoot, err := GetFinalizedEpoch()
 	if err != nil {
 		log.Println("fetch_beaconchain. GetFinalizedEpoch fail", err)
@@ -242,13 +241,10 @@ func Fetch(token string) (*types.PriceInfo, error) {
 
 	// epoch not updated, just return without fetching since effective-balance has not changed
 	if epoch <= finalizedEpoch {
-		// TODO: return current price or {nil, err}?
-		//		log.Println("fetch_beaconchain. epoch not updated")
 		return &types.PriceInfo{
 			Price:   string(latestChangesBytes),
 			RoundID: strconv.FormatUint(finalizedEpoch, 10),
 		}, nil
-
 	}
 
 	stakerChanges := make([][]int, 0, len(stakerValidators))
@@ -294,14 +290,6 @@ func Fetch(token string) (*types.PriceInfo, error) {
 	lock.RUnlock()
 
 	finalizedEpoch = epoch
-	if len(stakerChanges) == 0 {
-		if len(latestChangesBytes) > 0 {
-			latestChangesBytes = make([]byte, 0)
-			finalizedEpoch = epoch
-		}
-		log.Println("fetch_beaconchain. balance not changed since last epoch")
-		return nil, errBalanceNotChanged
-	}
 
 	latestChangesBytes = convertBalanceChangeToBytes(stakerChanges)
 
@@ -311,65 +299,11 @@ func Fetch(token string) (*types.PriceInfo, error) {
 	}, nil
 }
 
-// func GetFinalizedEpoch() (uint64, error) {
-// 	res, err := http.Get("https://beaconcha.in/api/v1/epoch/finalized")
-// 	if err != nil {
-// 		return 0, err
-// 	}
-// 	result, err := io.ReadAll(res.Body)
-// 	if err != nil {
-// 		return 0, err
-// 	}
-// 	res.Body.Close()
-// 	r := &ResultEpoch{}
-// 	_ = json.Unmarshal(result, r)
-// 	return r.Epoch, nil
-// }
-
-// func GetValidators(indexs []string, epoch uint64) ([][]uint64, error) {
-// 	var err error
-// 	if epoch == 0 {
-// 		epoch, err = GetFinalizedEpoch()
-// 		if err != nil {
-// 			return nil, err
-// 		}
-// 	}
-//
-// 	finalizedEpochStr := strconv.FormatUint(epoch, 10)
-//
-// 	base := urlQueryValidatorBalances.JoinPath(strings.Join(indexs, ","))
-//
-// 	value := queryValue
-// 	value.Add("latest_epoch", finalizedEpochStr)
-//
-// 	base.RawQuery = value.Encode()
-//
-// 	response, err := http.Get(base.String())
-// 	if err != nil {
-// 		fmt.Println(err)
-// 		return nil, err
-// 	}
-//
-// 	rBytes, err := io.ReadAll(response.Body)
-// 	if err != nil {
-// 		fmt.Println(err)
-// 		return nil, err
-// 	}
-// 	response.Body.Close()
-//
-// 	r := &ResultValidatorBalances{}
-// 	_ = json.Unmarshal(rBytes, r)
-// 	fmt.Println(r, r.DataValidatorBalance[1].ValidatorIndex, r.DataValidatorBalance[1].EffectiveBalance)
-// 	ret := make([][]uint64, 0, len(r.DataValidatorBalance))
-// 	for _, value := range r.DataValidatorBalance {
-// 		ret = append(ret, []uint64{value.ValidatorIndex, value.EffectiveBalance / divisor})
-// 	}
-// 	return ret, nil
-// }
-
 func convertBalanceChangeToBytes(stakerChanges [][]int) []byte {
 	if len(stakerChanges) == 0 {
-		return nil
+		// lenght equals to 0 means that alls takers have efb of 32 with 0 changes
+		ret := make([]byte, 32)
+		return ret
 	}
 	str := ""
 	index := 0
@@ -583,7 +517,9 @@ func GetFinalizedEpoch() (epoch uint64, stateRoot string, err error) {
 	}
 	result, _ := io.ReadAll(res.Body)
 	re := ResultHeader{}
-	json.Unmarshal(result, &re)
+	if err = json.Unmarshal(result, &re); err != nil {
+		return
+	}
 	res.Body.Close()
 	slot, _ := strconv.ParseUint(re.Data.Header.Message.Slot, 10, 64)
 	epoch = slot / 32
@@ -595,7 +531,9 @@ func GetFinalizedEpoch() (epoch uint64, stateRoot string, err error) {
 		}
 		result, _ = io.ReadAll(res.Body)
 		res.Body.Close()
-		json.Unmarshal(result, &re)
+		if err = json.Unmarshal(result, &re); err != nil {
+			return
+		}
 	}
 	stateRoot = re.Data.Header.Message.StateRoot
 	return

--- a/fetcher/beaconchain/beaconchain.go
+++ b/fetcher/beaconchain/beaconchain.go
@@ -95,12 +95,13 @@ var (
 	lock sync.RWMutex
 	// updated from oracle, deposit/withdraw
 	// TEST only. debug
-	validatorsTmp = []string{
-		"0xa1d1ad0714035353258038e964ae9675dc0252ee22cea896825c01458e1807bfad2f9969338798548d9858a571f7425c",
-		"0xb2ff4716ed345b05dd1dfc6a5a9fa70856d8c75dcc9e881dd2f766d5f891326f0d10e96f3a444ce6c912b69c22c6754d",
-	}
+	// validatorsTmp = []string{
+	// 	"0xa1d1ad0714035353258038e964ae9675dc0252ee22cea896825c01458e1807bfad2f9969338798548d9858a571f7425c",
+	// 	"0xb2ff4716ed345b05dd1dfc6a5a9fa70856d8c75dcc9e881dd2f766d5f891326f0d10e96f3a444ce6c912b69c22c6754d",
+	// }
 
-	stakerValidators = map[int]*validatorList{2: {0, validatorsTmp}}
+	// stakerValidators = map[int]*validatorList{2: {0, validatorsTmp}}
+	stakerValidators = make(map[int]*validatorList)
 	// latest finalized epoch we've got balances summarized for stakers
 	finalizedEpoch uint64
 	// latest stakerBalanceChanges, initialized as 0 change (256-0 of 1st parts means that all stakers have 32 efb)

--- a/fetcher/beaconchain/beaconchain_test.go
+++ b/fetcher/beaconchain/beaconchain_test.go
@@ -1,6 +1,7 @@
 package beaconchain
 
 import (
+	"net/url"
 	"testing"
 )
 
@@ -10,8 +11,9 @@ func TestGetEpoch(t *testing.T) {
 		"0xa1d1ad0714035353258038e964ae9675dc0252ee22cea896825c01458e1807bfad2f9969338798548d9858a571f7425c",
 		"0xb2ff4716ed345b05dd1dfc6a5a9fa70856d8c75dcc9e881dd2f766d5f891326f0d10e96f3a444ce6c912b69c22c6754d",
 	}
-	_, stateRoot, _ := GetFinalizedEpochAnkr()
+	urlEndpoint, _ = url.Parse("https://rpc.ankr.com/premium-http/eth_beacon/a5d2626c4027e6d924c870d2558bc774bc995ce917a17a654a92856b3279a586")
+	_, stateRoot, _ := GetFinalizedEpoch()
 	//GetValidatorsAnkr([]string{"0xa1d1ad0714035353258038e964ae9675dc0252ee22cea896825c01458e1807bfad2f9969338798548d9858a571f7425c"}, stateRoot)
 	//GetValidatorsAnkr([]string{"0xb2ff4716ed345b05dd1dfc6a5a9fa70856d8c75dcc9e881dd2f766d5f891326f0d10e96f3a444ce6c912b69c22c6754d"}, stateRoot)
-	GetValidatorsAnkr(validators, stateRoot)
+	GetValidators(validators, stateRoot)
 }

--- a/fetcher/beaconchain/decode_test.go
+++ b/fetcher/beaconchain/decode_test.go
@@ -1,0 +1,13 @@
+package beaconchain
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDecode(t *testing.T) {
+	bytes := convertBalanceChangeToBytes([][]int{})
+	stakerChanges, err := parseBalanceChange(bytes, stakerList{})
+
+	fmt.Println(stakerChanges, err)
+}

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -162,10 +162,8 @@ func (s *source) AddToken(name string) bool {
 			for {
 				select {
 				case <-tic.C:
-					fmt.Printf("debug---fetch_triggered by tic.interval.30, token%s\r\n", tName)
 					price, err := s.fetch(tName)
 					prevPrice := priceInfo.GetInfo()
-					fmt.Printf("debug----token:%s, price:%v, length_of_bytes:%d\r\n", tName, price, len(price.Price))
 					if err == nil && (prevPrice.Price != price.Price || prevPrice.Decimal != price.Decimal) {
 						priceInfo.UpdateInfo(price)
 						log.Printf("update token:%s, price:%s, decimal:%d", tName, price.Price, price.Decimal)
@@ -196,10 +194,8 @@ func (s *source) Fetch(interval time.Duration) {
 				for {
 					select {
 					case <-tic.C:
-						fmt.Printf("debug---fetch_triggered by tic.interval.30, token%s\r\n", tName)
 						price, err := s.fetch(tName)
 						prevPrice := priceInfo.GetInfo()
-						fmt.Printf("debug----token:%s, price:%v, length_of_bytes:%d\r\n", tName, price, len(price.Price))
 						if err == nil && (prevPrice.Price != price.Price || prevPrice.Decimal != price.Decimal) {
 							priceInfo.UpdateInfo(price)
 							log.Printf("update token:%s, price:%s, decimal:%d", tName, price.Price, price.Decimal)

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/atomic"
 )
 
-const defaultInterval = 10 * time.Second
+const defaultInterval = 30 * time.Second
 
 var sourcesMap sync.Map
 var tokensMap sync.Map
@@ -162,8 +162,10 @@ func (s *source) AddToken(name string) bool {
 			for {
 				select {
 				case <-tic.C:
+					fmt.Printf("debug---fetch_triggered by tic.interval.30, token%s\r\n", tName)
 					price, err := s.fetch(tName)
 					prevPrice := priceInfo.GetInfo()
+					fmt.Printf("debug----token:%s, price:%v, length_of_bytes:%d\r\n", tName, price, len(price.Price))
 					if err == nil && (prevPrice.Price != price.Price || prevPrice.Decimal != price.Decimal) {
 						priceInfo.UpdateInfo(price)
 						log.Printf("update token:%s, price:%s, decimal:%d", tName, price.Price, price.Decimal)
@@ -194,8 +196,10 @@ func (s *source) Fetch(interval time.Duration) {
 				for {
 					select {
 					case <-tic.C:
+						fmt.Printf("debug---fetch_triggered by tic.interval.30, token%s\r\n", tName)
 						price, err := s.fetch(tName)
 						prevPrice := priceInfo.GetInfo()
+						fmt.Printf("debug----token:%s, price:%v, length_of_bytes:%d\r\n", tName, price, len(price.Price))
 						if err == nil && (prevPrice.Price != price.Price || prevPrice.Decimal != price.Decimal) {
 							priceInfo.UpdateInfo(price)
 							log.Printf("update token:%s, price:%s, decimal:%d", tName, price.Price, price.Decimal)
@@ -304,22 +308,6 @@ func (f *Fetcher) StartAll() context.CancelFunc {
 						break
 					}
 				}
-				//	case updateInfo := <-f.nativeTokenValidatorsUpdate:
-				//		// TODO: v1 support eth-native-restaking only, refactor this after solana introduced
-				//		parsedInfo := strings.Split(updateInfo.info, "_")
-				//		if len(parsedInfo) != 4 {
-				//			// TODO: should not happen
-				//			continue
-				//		}
-				//		stakerIdx, _ := strconv.ParseInt(parsedInfo[1], 10, 64)
-				//		validatorPubkey := parsedInfo[2]
-				//		validatorsSize, _ := strconv.ParseUint(parsedInfo[3], 10, 64)
-				//		if beaconchain.UpdateStakerValidators(int(stakerIdx), validatorPubkey, parsedInfo[0] == "deposit", validatorsSize) {
-				//			updateInfo.success <- true
-				//		} else {
-				//			updateInfo.success <- false
-				//		}
-
 				// add tokens for a existing source
 			case <-f.configSource:
 				// TODO: we currently don't handle the request like 'remove token', if we do that support, we should take care of the process in reading routine

--- a/go.mod
+++ b/go.mod
@@ -241,9 +241,6 @@ replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 
-	// debug. test only
-	github.com/ExocoreNetwork/exocore v0.0.0-20240926031231-b7a9717fb266 => /Users/linqing/workplace/github.com/leonz/exocore
-
 	// use Cosmos-SDK fork to enable Ledger functionality
 	github.com/cosmos/cosmos-sdk => github.com/evmos/cosmos-sdk v0.47.5-evmos.2
 	//fix cosmos-sdk error

--- a/go.mod
+++ b/go.mod
@@ -241,6 +241,9 @@ replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 
+	// debug. test only
+	github.com/ExocoreNetwork/exocore v0.0.0-20240926031231-b7a9717fb266 => /Users/linqing/workplace/github.com/leonz/exocore
+
 	// use Cosmos-SDK fork to enable Ledger functionality
 	github.com/cosmos/cosmos-sdk => github.com/evmos/cosmos-sdk v0.47.5-evmos.2
 	//fix cosmos-sdk error


### PR DESCRIPTION
We use 32 as base to calculate the effective-balance change, so when all effective-balances are 32 it might not meant no changes compared to current balances.
## Notable Change
- return balance change byte with 32 0s to indicate that all effective-balances are 32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging for configuration loading.
	- Streamlined handling of staker balances and epoch data.
	- Introduced a new test for decoding balance changes.

- **Bug Fixes**
	- Improved error handling during JSON unmarshalling.

- **Chores**
	- Updated `.gitignore` to include additional patterns.
	- Adjusted fetch interval timing from 10 seconds to 30 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->