### PR TITLE
add: version cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,6 @@ release:
 		release --clean --skip validate
 
 build:
-	go build -o ./build/price-feeder
+	go build -ldflags "-X github.com/ExocoreNetwork/price-feeder/version.Version=$(shell git describe --tags)" -o ./build/price-feeder
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@ PACKAGE_NAME          := github.com/ExocoreNetwork/price-feeder
 GOLANG_CROSS_VERSION  = v1.22-v2.0.0
 GOPATH ?= '$(HOME)/go'
 
+VERSION  := $(shell git describe --tags 2>/dev/null || echo "v0.0.0-unknown")
+COMMIT   := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+LDFLAGS := -X github.com/ExocoreNetwork/price-feeder/version.Version=$(VERSION) \
+           -X github.com/ExocoreNetwork/price-feeder/version.Commit=$(COMMIT) \
+           -X github.com/ExocoreNetwork/price-feeder/version.BuildDate=$(BUILD_DATE)
+
 release-dry-run:
 	docker run \
 		--rm \
@@ -31,6 +39,6 @@ release:
 		release --clean --skip validate
 
 build:
-	go build -ldflags "-X github.com/ExocoreNetwork/price-feeder/version.Version=$(shell git describe --tags)" -o ./build/price-feeder
+	go build -ldflags "$(LDFLAGS)" -o ./build/price-feeder
 
 .PHONY: build

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,5 +64,6 @@ func init() {
 	rootCmd.AddCommand(
 		startCmd,
 		debugStartCmd,
+		versionCmd,
 	)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/ExocoreNetwork/price-feeder/version"
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "display version information",
+	Long:  "display version information",
+	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		// do nothing here, just override persistentPreRunE defined in parent
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version.Version)
+	},
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Name, Version, Commit string
+var Version string


### PR DESCRIPTION
add cli to print version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a version command to the CLI, allowing users to retrieve the application's version information.

- **Chores**
	- Updated build process to dynamically set version information using Git tags.
	- Simplified version package by removing unnecessary variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->