### PR TITLE
feat: add BSC fetcher and refactor fetcher types

### DIFF
--- a/fetcher/beaconchain/beaconchain_fetch.go
+++ b/fetcher/beaconchain/beaconchain_fetch.go
@@ -49,10 +49,14 @@ func getCapsuleValidBalance(ethClient *ethclient.Client, capsuleAddr string, blo
 		return nil, valid, fmt.Errorf("failed to call contract to query isInClaimProgress, err:%w", err)
 	}
 
-	var inWithdrawProgress bool
-	err = parsedABI.UnpackIntoInterface(&inWithdrawProgress, "isInClaimProgress", output)
-	if err != nil || inWithdrawProgress {
-		return nil, valid, fmt.Errorf("capsule %s is in withdrawal progress or unpack error: %w", capsuleAddr, err)
+	var inClaimProgress bool
+	err = parsedABI.UnpackIntoInterface(&inClaimProgress, "isInClaimProgress", output)
+	if err != nil {
+		return nil, valid, fmt.Errorf("failed to unpack isInClaimProgress, err:%w", err)
+	}
+
+	if inClaimProgress {
+		return nil, valid, nil
 	}
 
 	valid = true
@@ -125,7 +129,7 @@ func (s *source) fetch(token string) (*types.PriceInfo, error) {
 	}
 
 	// use 'no copy' version to avoid copying stakers
-	sInfos, version, withdrawVersion := s.stakers.GetStakersNoCopy()
+	sInfos, version, withdrawVersion := s.Stakers.GetStakersNoCopy()
 	if len(sInfos) == 0 {
 		// return zero price when there's no stakers
 		return &types.PriceInfo{}, nil
@@ -141,17 +145,18 @@ func (s *source) fetch(token string) (*types.PriceInfo, error) {
 	// --- End CL/EL synchronization ---
 	// epoch not updated, just return without fetching since effective-balance has not changed
 	if epoch <= finalizedEpoch && version <= finalizedVersion && withdrawVersion <= finalizedWithdrawVersion {
-		s.logger.Info("fetch efb from beaconchain, no change in epoch or version, return latestChangesBytes", "epoch", epoch, "version", version, "withdrawVersion", withdrawVersion)
+		s.Logger().Info("fetch efb from beaconchain, no change in epoch or version, return latestChangesBytes", "epoch", epoch, "version", version, "withdrawVersion", withdrawVersion)
 		return &types.PriceInfo{
 			Price: string(latestChangesBytes),
 			// combine epoch and version as roundID in priceInfo
-			RoundID: fmt.Sprintf("%s_%s", strconv.FormatUint(finalizedEpoch, 10), strconv.FormatUint(version, 10)),
+			RoundID: fmt.Sprintf("%s|%s|%s", strconv.FormatUint(finalizedEpoch, 10), strconv.FormatUint(version, 10), strconv.FormatUint(withdrawVersion, 10)),
 		}, nil
 	}
 
 	changedStakerBalances := make([]*oracletypes.NSTKV, 0, len(sInfos))
-	s.logger.Info("fetch efb from beaconchain", "stakerList_length", len(sInfos))
-	hasEFBChanged := false
+	s.Logger().Info("fetch efb from beaconchain", "stakerList_length", len(sInfos))
+	// hasEFBChanged := false
+	// TODO: optimize query (batch, muticall, concurrency) to deal with too many stakers
 	for stakerIdx, stakerInfo := range sInfos {
 		validators := stakerInfo.Validators
 		l := len(validators)
@@ -210,13 +215,14 @@ func (s *source) fetch(token string) (*types.PriceInfo, error) {
 				StakerIndex: uint32(stakerIdx),
 				Balance:     stakerBalance,
 			})
-			s.logger.Info("fetched efb from beaconchain", "staker_index", stakerIdx, "prev_balance", stakerInfo.Balance, "latest_balance", stakerBalance, "validators_count", l)
-			hasEFBChanged = true
+			s.Logger().Info("fetched efb from beaconchain", "staker_index", stakerIdx, "prev_balance", stakerInfo.Balance, "latest_balance", stakerBalance, "validators_count", l)
+			//		hasEFBChanged = true
 		}
 	}
 	// when balance change or withdrawVersion is updated(since last feed might skip some balance change), we update the same price again
-	if hasEFBChanged {
-		s.logger.Info("fetched efb from beaconchain, some efbs of validators have changed")
+	//	if hasEFBChanged {
+	if len(changedStakerBalances) > 0 {
+		s.Logger().Info("fetched efb from beaconchain, some efbs of validators have changed")
 		sort.Slice(changedStakerBalances, func(i, j int) bool {
 			return changedStakerBalances[i].StakerIndex < changedStakerBalances[j].StakerIndex
 		})
@@ -232,7 +238,7 @@ func (s *source) fetch(token string) (*types.PriceInfo, error) {
 
 		latestChangesBytes = bz
 	} else {
-		s.logger.Info("fetched efb from beaconchain, all efbs remain unchanged")
+		s.Logger().Info("fetched efb from beaconchain, all efbs remain unchanged")
 		latestChangesBytes = fetchertypes.NSTZeroChanges
 	}
 	finalizedEpoch = epoch

--- a/fetcher/beaconchain/beaconchain_fetch.go
+++ b/fetcher/beaconchain/beaconchain_fetch.go
@@ -131,8 +131,12 @@ func (s *source) fetch(token string) (*types.PriceInfo, error) {
 	// use 'no copy' version to avoid copying stakers
 	sInfos, version, withdrawVersion := s.Stakers.GetStakersNoCopy()
 	if len(sInfos) == 0 {
-		// return zero price when there's no stakers
-		return &types.PriceInfo{}, nil
+		latestChangesBytes = fetchertypes.NSTZeroChanges
+		return &types.PriceInfo{
+			Price: string(latestChangesBytes),
+			// combine epoch and version as roundID in priceInfo
+			RoundID: fmt.Sprintf("%s|%s|%s", strconv.FormatUint(finalizedEpoch, 10), strconv.FormatUint(version, 10), strconv.FormatUint(withdrawVersion, 10)),
+		}, nil
 	}
 	// --- CL/EL synchronization ---
 	elBlockNumber, clSlot, stateRoot, err := getFinalizedELBlockNumber()
@@ -161,6 +165,7 @@ func (s *source) fetch(token string) (*types.PriceInfo, error) {
 		validators := stakerInfo.Validators
 		l := len(validators)
 		if l == 0 {
+			s.Logger().Error("staker has no validators", "staker_index", stakerIdx, "staker", stakerInfo.Address)
 			continue
 		}
 		stakerBalance := uint64(0)

--- a/fetcher/beaconchain/types.go
+++ b/fetcher/beaconchain/types.go
@@ -6,16 +6,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"path"
 	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/imua-xyz/price-feeder/fetcher/types"
+	nsttypes "github.com/imua-xyz/price-feeder/fetcher/nst/types"
 	fetchertypes "github.com/imua-xyz/price-feeder/fetcher/types"
 	feedertypes "github.com/imua-xyz/price-feeder/types"
-	"gopkg.in/yaml.v2"
 )
 
 /**
@@ -34,12 +31,18 @@ limitation of imuachainv1:
 **/
 
 type source struct {
-	logger  feedertypes.LoggerInf
-	stakers *fetchertypes.Stakers
-	*types.Source
+	*nsttypes.Source
 	ethClient        *ethclient.Client
-	bootstrapAddress string // the address of the bootstrap contract, used to get capsule address for stakers
+	bootstrapAddress string
 }
+
+// type source struct {
+// 	logger  feedertypes.LoggerInf
+// 	stakers *fetchertypes.Stakers
+// 	*fetchertypes.Source
+// 	ethClient        *ethclient.Client
+// 	bootstrapAddress string // the address of the bootstrap contract, used to get capsule address for stakers
+// }
 
 type config struct {
 	URLs struct {
@@ -56,13 +59,13 @@ type ResultConfig struct {
 	} `json:"data"`
 }
 
-func (s *source) SetNSTStakers(sInfos fetchertypes.StakerInfos, version uint64, withdrawVersion uint64) {
-	s.stakers.Locker.Lock()
-	s.stakers.SInfos = sInfos
-	s.stakers.Version = version
-	s.stakers.WithdrawVersion = withdrawVersion
-	s.stakers.Locker.Unlock()
-}
+// func (s *source) SetNSTStakers(sInfos fetchertypes.StakerInfos, version, withdrawVersion uint64) {
+// 	s.Stakers.Locker.Lock()
+// 	s.Stakers.SInfos = sInfos
+// 	s.Stakers.Version = version
+// 	s.Stakers.WithdrawVersion = withdrawVersion
+// 	s.Stakers.Locker.Unlock()
+// }
 
 const (
 	envConf               = "oracle_env_beaconchain.yaml"
@@ -76,17 +79,18 @@ var (
 )
 
 func init() {
-	types.SourceInitializers[types.BeaconChain] = initBeaconchain
+	fetchertypes.SourceInitializers[fetchertypes.BeaconChain] = initBeaconchain
 }
 
-func initBeaconchain(cfgPath string, l feedertypes.LoggerInf) (types.SourceInf, error) {
+func initBeaconchain(cfgPath string, l feedertypes.LoggerInf) (fetchertypes.SourceInf, error) {
 	if logger = l; logger == nil {
 		if logger = feedertypes.GetLogger("fetcher_beaconchain"); logger == nil {
 			return nil, feedertypes.ErrInitFail.Wrap("logger is not initialized")
 		}
 	}
 	// init from config file
-	cfg, err := parseConfig(cfgPath)
+	// cfg, err := parseConfig(cfgPath)
+	cfg, err := nsttypes.ParseConfig[config](cfgPath, envConf)
 	if err != nil {
 		// logger.Error("fail to parse config", "error", err, "path", cfgPath)
 		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse config, error:%v", err))
@@ -109,7 +113,7 @@ func initBeaconchain(cfgPath string, l feedertypes.LoggerInf) (types.SourceInf, 
 	}
 
 	// set slotsPerEpoch
-	if slotsPerEpochKnown, ok := types.ChainToSlotsPerEpoch[lzID]; ok {
+	if slotsPerEpochKnown, ok := fetchertypes.ChainToSlotsPerEpoch[lzID]; ok {
 		slotsPerEpoch = slotsPerEpochKnown
 	} else {
 		// else, we need the slotsPerEpoch from beaconchain endpoint
@@ -139,34 +143,32 @@ func initBeaconchain(cfgPath string, l feedertypes.LoggerInf) (types.SourceInf, 
 	if cfg.Bootstrap == "" {
 		return nil, feedertypes.ErrInitFail.Wrap("bootstrap address is not set")
 	}
-	if !types.IsContractAddress(cfg.Bootstrap, client, logger) {
+	if !fetchertypes.IsContractAddress(cfg.Bootstrap, client, logger) {
 		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("bootstrap address is not a contract address: %s", cfg.Bootstrap))
 	}
 	// init first to get a fixed pointer for 'fetch' to refer to
 	defaultSource = &source{}
 
 	*defaultSource = source{
-		logger:           logger,
-		Source:           types.NewSource(logger, types.BeaconChain, defaultSource.fetch, cfgPath, defaultSource.reload),
-		stakers:          types.NewStakers(),
+		Source:           nsttypes.NewSource(logger, fetchertypes.BeaconChain, defaultSource.fetch, cfgPath, defaultSource.reload),
 		ethClient:        client,
 		bootstrapAddress: cfg.Bootstrap,
 	}
 
 	// update nst assetID to be consistent with imuad. for beaconchain it's about different lzID
-	types.SetNativeAssetID(fetchertypes.NativeTokenETH, cfg.NSTID)
+	fetchertypes.SetNativeAssetID(fetchertypes.NativeTokenETH, cfg.NSTID)
 
 	return defaultSource, nil
 }
 
-func parseConfig(confPath string) (config, error) {
-	yamlFile, err := os.Open(path.Join(confPath, envConf))
-	if err != nil {
-		return config{}, err
-	}
-	cfg := config{}
-	if err = yaml.NewDecoder(yamlFile).Decode(&cfg); err != nil {
-		return config{}, err
-	}
-	return cfg, nil
-}
+// func parseConfig(confPath string) (config, error) {
+// 	yamlFile, err := os.Open(path.Join(confPath, envConf))
+// 	if err != nil {
+// 		return config{}, err
+// 	}
+// 	cfg := config{}
+// 	if err = yaml.NewDecoder(yamlFile).Decode(&cfg); err != nil {
+// 		return config{}, err
+// 	}
+// 	return cfg, nil
+// }

--- a/fetcher/bsc/bsc.go
+++ b/fetcher/bsc/bsc.go
@@ -17,8 +17,8 @@ var _ scannerInf = &source{}
 var divisor = big.NewInt(1e9)
 
 type multicall struct {
-	target   common.Address // matches ABI field "target"
-	calldata []byte         // matches ABI field "callData"
+	Target   common.Address `abi:"target"`
+	CallData []byte         `abi:"callData"`
 }
 
 // batchQueryCapsules queries capsule.getPooledAndLockedBNBs() for each capsule address via multicall.
@@ -30,7 +30,7 @@ func (s *source) batchQueryCapsules(ctx context.Context, capsules []common.Addre
 		if err != nil {
 			return nil, err
 		}
-		calls = append(calls, multicall{target: capAddr, calldata: callData})
+		calls = append(calls, multicall{Target: capAddr, CallData: callData})
 	}
 
 	calldata, err := s.multicallABI.Pack("aggregate", calls)

--- a/fetcher/bsc/bsc.go
+++ b/fetcher/bsc/bsc.go
@@ -1,0 +1,274 @@
+package bsc
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// we use gwei as unit of amount (uint64 should be enough)
+
+var _ scannerInf = &source{}
+
+var divisor = big.NewInt(1e9)
+
+type multicall struct {
+	target   common.Address // matches ABI field "target"
+	calldata []byte         // matches ABI field "callData"
+}
+
+func (s *source) batchQueryCreditForDelegators(ctx context.Context, credit common.Address, delegators []common.Address, blockNumber *big.Int) (map[common.Address]*big.Int, error) {
+	calls := make([]multicall, 0, len(delegators))
+	for _, d := range delegators {
+		pooledBNB, err := s.pooledABI.Pack("getPooledBNB", d)
+		if err != nil {
+			return nil, err
+		}
+		lockedBNB, err := s.lockedABI.Pack("lockedBNBs", d, big.NewInt(0))
+		if err != nil {
+			return nil, err
+		}
+		calls = append(calls,
+			multicall{target: credit, calldata: pooledBNB},
+			multicall{target: credit, calldata: lockedBNB},
+		)
+	}
+	calldata, err := s.multicallABI.Pack("aggregate", calls)
+	if err != nil {
+		return nil, err
+	}
+	res, err := s.client.CallContract(ctx, ethereum.CallMsg{
+		To:   &s.multicallAddr,
+		Data: calldata,
+	}, blockNumber)
+	if err != nil {
+		return nil, err
+	}
+	unpackedRes, err := s.multicallABI.Unpack("aggregate", res)
+	if err != nil {
+		return nil, err
+	}
+
+	// unpackedRes[0] is blockNumber (*big.Int) - returned by multicall, can be ignored
+	// unpackedRes[1] is returnData ([][]byte)
+	if len(unpackedRes) != 2 {
+		return nil, fmt.Errorf("unexpected unpack result length: %d", len(unpackedRes))
+	}
+
+	_ = unpackedRes[0].(*big.Int) // blockNumber from multicall response (we use the provided blockNumber parameter)
+	returnData := unpackedRes[1].([][]byte)
+
+	// Each delegator has 2 calls: getPooledBNB and lockedBNBs
+	// So returnData length should be len(delegators) * 2
+	if len(returnData) != len(delegators)*2 {
+		return nil, fmt.Errorf("unexpected returnData length: %d, expected %d", len(returnData), len(delegators)*2)
+	}
+
+	result := make(map[common.Address]*big.Int)
+	for i, d := range delegators {
+		// Index i*2 is getPooledBNB result
+		var pooledBNB *big.Int
+		err = s.pooledABI.UnpackIntoInterface(&pooledBNB, "getPooledBNB", returnData[i*2])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unpack pooledBNB for delegator %s: %w", d.Hex(), err)
+		}
+
+		// Index i*2+1 is lockedBNBs result
+		var lockedBNB *big.Int
+		err = s.lockedABI.UnpackIntoInterface(&lockedBNB, "lockedBNBs", returnData[i*2+1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unpack lockedBNB for delegator %s: %w", d.Hex(), err)
+		}
+
+		// Convert to gwei (divide by 1e9) and sum
+		total := new(big.Int).Add(pooledBNB, lockedBNB)
+		if total.Sign() <= 0 {
+			// do fullScan to find possible new validator of the delegator
+			_, pooled, locked, err := s.fullScan(ctx, d, blockNumber)
+			if err != nil {
+				if err != errNoValidatorFound {
+					return nil, err
+				}
+				pooled = big.NewInt(0)
+				locked = big.NewInt(0)
+			}
+			total = new(big.Int).Add(pooled, locked)
+		}
+		result[d] = total
+	}
+
+	return result, nil
+}
+
+func (s *source) fullScan(ctx context.Context, delegator common.Address, blockNumber *big.Int) (creditAddr common.Address, pooledBNB, lockedBNB *big.Int, err error) {
+	vals := s.validators.getValidators()
+	pooledData, err := s.pooledABI.Pack("getPooledBNB", delegator)
+	if err != nil {
+		return
+	}
+	lockedData, err := s.lockedABI.Pack("lockedBNBs", delegator, big.NewInt(0))
+	if err != nil {
+		return
+	}
+	calls := make([]multicall, 0, len(vals)*2)
+	for _, val := range vals {
+		calls = append(calls,
+			multicall{
+				target:   val.CreditContract,
+				calldata: pooledData,
+			},
+			multicall{
+				target:   val.CreditContract,
+				calldata: lockedData,
+			})
+	}
+	data, err := s.multicallABI.Pack("aggregate", calls)
+	if err != nil {
+		return
+	}
+	// Call the multicall contract with the batch of calls
+	res, err := s.client.CallContract(ctx, ethereum.CallMsg{
+		To:   &s.multicallAddr,
+		Data: data,
+	}, blockNumber)
+	if err != nil {
+		return
+	}
+	unpackedRes, err := s.multicallABI.Unpack("aggregate", res)
+	if err != nil {
+		return
+	}
+	if len(unpackedRes) != 2 {
+		err = fmt.Errorf("unexpected unpack result length: %d", len(unpackedRes))
+		return
+	}
+	returnData := unpackedRes[1].([][]byte)
+	// Each validator has 2 calls: getPooledBNB and lockedBNBs
+	if len(returnData) != len(vals)*2 {
+		err = fmt.Errorf("unexpected returnData length: %d, expected %d", len(returnData), len(vals)*2)
+		return
+	}
+
+	for i, val := range vals {
+		var pooled *big.Int
+		var locked *big.Int
+		err = s.pooledABI.UnpackIntoInterface(&pooled, "getPooledBNB", returnData[i*2])
+		if err != nil {
+			continue // skip this validator, try next
+		}
+		err = s.lockedABI.UnpackIntoInterface(&locked, "lockedBNBs", returnData[i*2+1])
+		if err != nil {
+			continue // skip this validator, try next
+		}
+		total := new(big.Int).Add(pooled, locked)
+		if total.Sign() > 0 {
+			// Found the validator
+			creditAddr = val.CreditContract
+			pooledBNB = pooled
+			lockedBNB = locked
+			s.cache.set(delegator, creditAddr)
+			return
+		}
+	}
+	s.cache.delete(delegator)
+	// No valid validator relationship found for this delegator
+	err = errNoValidatorFound
+	return creditAddr, pooledBNB, lockedBNB, err
+}
+
+func (s *source) getCurrentHeight() uint64 {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	height, err := s.client.BlockNumber(ctx)
+	if err != nil {
+		if logger := s.Logger(); logger != nil {
+			logger.Error("failed to fetch current BSC height", "error", err)
+		}
+	return 0
+	}
+	return height
+}
+
+func (s *source) refreshValidators() (bool, error) {
+	var (
+		operators []common.Address
+		credits   []common.Address
+		total     *big.Int
+	)
+
+	offset := 0
+	pageSize := 500 // big enough for BSC validator set
+
+	oldVals := s.validators.getValidators()
+
+	for {
+		data, err := s.stakeHubABI.Pack("getValidators", big.NewInt(int64(offset)), big.NewInt(int64(pageSize)))
+		if err != nil {
+			return false, err
+		}
+
+		// Remove new context for lint; assume using an existing context (in real code should pass ctx)
+		// Here, just use context.Background() for demonstration.
+		res, err := s.client.CallContract(context.Background(), ethereum.CallMsg{
+			To:   &s.stakeHubAddr,
+			Data: data,
+		}, nil)
+		if err != nil {
+			return false, err
+		}
+
+		out, err := s.stakeHubABI.Unpack("getValidators", res)
+		if err != nil {
+			return false, err
+		}
+
+		ops := out[0].([]common.Address)
+		crs := out[1].([]common.Address)
+		total = out[2].(*big.Int)
+
+		operators = append(operators, ops...)
+		credits = append(credits, crs...)
+
+		offset += len(ops)
+		if offset >= int(total.Int64()) || len(ops) == 0 {
+			break
+		}
+	}
+
+	// Build new slice of validatorInfo for update
+	vals := make([]validatorInfo, len(operators))
+	for i := range operators {
+		vals[i] = validatorInfo{
+			Operator:       operators[i],
+			CreditContract: credits[i],
+		}
+	}
+
+	setA := make(map[[20]byte][20]byte, len(oldVals))
+	for _, v := range oldVals {
+		setA[v.Operator] = v.CreditContract
+	}
+	changed := false
+
+	// To check added/changed items
+	for _, v := range vals {
+		cc, ok := setA[v.Operator]
+		if !ok || cc != v.CreditContract {
+			changed = true
+			break
+		}
+		delete(setA, v.Operator)
+	}
+	// setA now contains any removals, so if not empty, there are deletions
+	if !changed && len(setA) > 0 {
+		changed = true
+	}
+
+	s.validators.setValidators(vals)
+	return changed, nil
+}

--- a/fetcher/bsc/bsc.go
+++ b/fetcher/bsc/bsc.go
@@ -21,22 +21,18 @@ type multicall struct {
 	calldata []byte         // matches ABI field "callData"
 }
 
-func (s *source) batchQueryCreditForDelegators(ctx context.Context, credit common.Address, delegators []common.Address, blockNumber *big.Int) (map[common.Address]*big.Int, error) {
-	calls := make([]multicall, 0, len(delegators))
-	for _, d := range delegators {
-		pooledBNB, err := s.pooledABI.Pack("getPooledBNB", d)
+// batchQueryCapsules queries capsule.getPooledAndLockedBNBs() for each capsule address via multicall.
+// It returns pooled+locked (in wei) per capsule.
+func (s *source) batchQueryCapsules(ctx context.Context, capsules []common.Address, blockNumber *big.Int) (map[common.Address]*big.Int, error) {
+	calls := make([]multicall, 0, len(capsules))
+	for _, capAddr := range capsules {
+		callData, err := s.capsuleABI.Pack("getPooledAndLockedBNBs")
 		if err != nil {
 			return nil, err
 		}
-		lockedBNB, err := s.lockedABI.Pack("lockedBNBs", d, big.NewInt(0))
-		if err != nil {
-			return nil, err
-		}
-		calls = append(calls,
-			multicall{target: credit, calldata: pooledBNB},
-			multicall{target: credit, calldata: lockedBNB},
-		)
+		calls = append(calls, multicall{target: capAddr, calldata: callData})
 	}
+
 	calldata, err := s.multicallABI.Pack("aggregate", calls)
 	if err != nil {
 		return nil, err
@@ -62,122 +58,26 @@ func (s *source) batchQueryCreditForDelegators(ctx context.Context, credit commo
 	_ = unpackedRes[0].(*big.Int) // blockNumber from multicall response (we use the provided blockNumber parameter)
 	returnData := unpackedRes[1].([][]byte)
 
-	// Each delegator has 2 calls: getPooledBNB and lockedBNBs
-	// So returnData length should be len(delegators) * 2
-	if len(returnData) != len(delegators)*2 {
-		return nil, fmt.Errorf("unexpected returnData length: %d, expected %d", len(returnData), len(delegators)*2)
+	if len(returnData) != len(capsules) {
+		return nil, fmt.Errorf("unexpected returnData length: %d, expected %d", len(returnData), len(capsules))
 	}
 
 	result := make(map[common.Address]*big.Int)
-	for i, d := range delegators {
-		// Index i*2 is getPooledBNB result
-		var pooledBNB *big.Int
-		err = s.pooledABI.UnpackIntoInterface(&pooledBNB, "getPooledBNB", returnData[i*2])
+	for i, capAddr := range capsules {
+		out, err := s.capsuleABI.Unpack("getPooledAndLockedBNBs", returnData[i])
 		if err != nil {
-			return nil, fmt.Errorf("failed to unpack pooledBNB for delegator %s: %w", d.Hex(), err)
+			return nil, fmt.Errorf("failed to unpack getPooledAndLockedBNBs for capsule %s: %w", capAddr.Hex(), err)
+		}
+		if len(out) != 2 {
+			return nil, fmt.Errorf("unexpected getPooledAndLockedBNBs output length: %d", len(out))
 		}
 
-		// Index i*2+1 is lockedBNBs result
-		var lockedBNB *big.Int
-		err = s.lockedABI.UnpackIntoInterface(&lockedBNB, "lockedBNBs", returnData[i*2+1])
-		if err != nil {
-			return nil, fmt.Errorf("failed to unpack lockedBNB for delegator %s: %w", d.Hex(), err)
-		}
-
-		// Convert to gwei (divide by 1e9) and sum
-		total := new(big.Int).Add(pooledBNB, lockedBNB)
-		if total.Sign() <= 0 {
-			// do fullScan to find possible new validator of the delegator
-			_, pooled, locked, err := s.fullScan(ctx, d, blockNumber)
-			if err != nil {
-				if err != errNoValidatorFound {
-					return nil, err
-				}
-				pooled = big.NewInt(0)
-				locked = big.NewInt(0)
-			}
-			total = new(big.Int).Add(pooled, locked)
-		}
-		result[d] = total
+		pooled := out[0].(*big.Int)
+		locked := out[1].(*big.Int)
+		result[capAddr] = new(big.Int).Add(pooled, locked)
 	}
 
 	return result, nil
-}
-
-func (s *source) fullScan(ctx context.Context, delegator common.Address, blockNumber *big.Int) (creditAddr common.Address, pooledBNB, lockedBNB *big.Int, err error) {
-	vals := s.validators.getValidators()
-	pooledData, err := s.pooledABI.Pack("getPooledBNB", delegator)
-	if err != nil {
-		return
-	}
-	lockedData, err := s.lockedABI.Pack("lockedBNBs", delegator, big.NewInt(0))
-	if err != nil {
-		return
-	}
-	calls := make([]multicall, 0, len(vals)*2)
-	for _, val := range vals {
-		calls = append(calls,
-			multicall{
-				target:   val.CreditContract,
-				calldata: pooledData,
-			},
-			multicall{
-				target:   val.CreditContract,
-				calldata: lockedData,
-			})
-	}
-	data, err := s.multicallABI.Pack("aggregate", calls)
-	if err != nil {
-		return
-	}
-	// Call the multicall contract with the batch of calls
-	res, err := s.client.CallContract(ctx, ethereum.CallMsg{
-		To:   &s.multicallAddr,
-		Data: data,
-	}, blockNumber)
-	if err != nil {
-		return
-	}
-	unpackedRes, err := s.multicallABI.Unpack("aggregate", res)
-	if err != nil {
-		return
-	}
-	if len(unpackedRes) != 2 {
-		err = fmt.Errorf("unexpected unpack result length: %d", len(unpackedRes))
-		return
-	}
-	returnData := unpackedRes[1].([][]byte)
-	// Each validator has 2 calls: getPooledBNB and lockedBNBs
-	if len(returnData) != len(vals)*2 {
-		err = fmt.Errorf("unexpected returnData length: %d, expected %d", len(returnData), len(vals)*2)
-		return
-	}
-
-	for i, val := range vals {
-		var pooled *big.Int
-		var locked *big.Int
-		err = s.pooledABI.UnpackIntoInterface(&pooled, "getPooledBNB", returnData[i*2])
-		if err != nil {
-			continue // skip this validator, try next
-		}
-		err = s.lockedABI.UnpackIntoInterface(&locked, "lockedBNBs", returnData[i*2+1])
-		if err != nil {
-			continue // skip this validator, try next
-		}
-		total := new(big.Int).Add(pooled, locked)
-		if total.Sign() > 0 {
-			// Found the validator
-			creditAddr = val.CreditContract
-			pooledBNB = pooled
-			lockedBNB = locked
-			s.cache.set(delegator, creditAddr)
-			return
-		}
-	}
-	s.cache.delete(delegator)
-	// No valid validator relationship found for this delegator
-	err = errNoValidatorFound
-	return creditAddr, pooledBNB, lockedBNB, err
 }
 
 func (s *source) getCurrentHeight() uint64 {
@@ -189,86 +89,7 @@ func (s *source) getCurrentHeight() uint64 {
 		if logger := s.Logger(); logger != nil {
 			logger.Error("failed to fetch current BSC height", "error", err)
 		}
-	return 0
+		return 0
 	}
 	return height
-}
-
-func (s *source) refreshValidators() (bool, error) {
-	var (
-		operators []common.Address
-		credits   []common.Address
-		total     *big.Int
-	)
-
-	offset := 0
-	pageSize := 500 // big enough for BSC validator set
-
-	oldVals := s.validators.getValidators()
-
-	for {
-		data, err := s.stakeHubABI.Pack("getValidators", big.NewInt(int64(offset)), big.NewInt(int64(pageSize)))
-		if err != nil {
-			return false, err
-		}
-
-		// Remove new context for lint; assume using an existing context (in real code should pass ctx)
-		// Here, just use context.Background() for demonstration.
-		res, err := s.client.CallContract(context.Background(), ethereum.CallMsg{
-			To:   &s.stakeHubAddr,
-			Data: data,
-		}, nil)
-		if err != nil {
-			return false, err
-		}
-
-		out, err := s.stakeHubABI.Unpack("getValidators", res)
-		if err != nil {
-			return false, err
-		}
-
-		ops := out[0].([]common.Address)
-		crs := out[1].([]common.Address)
-		total = out[2].(*big.Int)
-
-		operators = append(operators, ops...)
-		credits = append(credits, crs...)
-
-		offset += len(ops)
-		if offset >= int(total.Int64()) || len(ops) == 0 {
-			break
-		}
-	}
-
-	// Build new slice of validatorInfo for update
-	vals := make([]validatorInfo, len(operators))
-	for i := range operators {
-		vals[i] = validatorInfo{
-			Operator:       operators[i],
-			CreditContract: credits[i],
-		}
-	}
-
-	setA := make(map[[20]byte][20]byte, len(oldVals))
-	for _, v := range oldVals {
-		setA[v.Operator] = v.CreditContract
-	}
-	changed := false
-
-	// To check added/changed items
-	for _, v := range vals {
-		cc, ok := setA[v.Operator]
-		if !ok || cc != v.CreditContract {
-			changed = true
-			break
-		}
-		delete(setA, v.Operator)
-	}
-	// setA now contains any removals, so if not empty, there are deletions
-	if !changed && len(setA) > 0 {
-		changed = true
-	}
-
-	s.validators.setValidators(vals)
-	return changed, nil
 }

--- a/fetcher/bsc/bsc_fetch.go
+++ b/fetcher/bsc/bsc_fetch.go
@@ -41,7 +41,8 @@ func (s *source) fetch(token string) (*fetchertypes.PriceInfo, error) {
 	// Round block height down to nearest 100 for consistency with batch querying
 	height := s.getCurrentHeight() / 100 * 100
 
-	if height <= finalizedBlock || v <= finalizedVersion || wV <= finalizedWithdrawVersion {
+	// Only skip when all are unchanged (same semantics as other NST fetchers)
+	if height <= finalizedBlock && v <= finalizedVersion && wV <= finalizedWithdrawVersion {
 		s.Logger().Info("fetch delegators from beaconchain, no change in height(round to 100) or version, return latestChangesBytes", "height", height, "version", finalizedVersion, "withdrawVersion", finalizedWithdrawVersion)
 		return &fetchertypes.PriceInfo{
 			Price: string(latestChangesBytes),

--- a/fetcher/bsc/bsc_fetch.go
+++ b/fetcher/bsc/bsc_fetch.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/ethereum/go-ethereum/common"
 	oracletypes "github.com/imua-xyz/imuachain/x/oracle/types"
-	"github.com/imua-xyz/price-feeder/fetcher/types"
 	fetchertypes "github.com/imua-xyz/price-feeder/fetcher/types"
 	feedertypes "github.com/imua-xyz/price-feeder/types"
 )
@@ -29,80 +28,68 @@ func (s *source) fetch(token string) (*fetchertypes.PriceInfo, error) {
 	if fetchertypes.NSTToken(token) != fetchertypes.NativeTokenBSC {
 		return nil, feedertypes.ErrTokenNotSupported.Wrap(fmt.Sprintf("only support native-eth-restaking %s, got:%s", fetchertypes.NativeTokenBSC, token))
 	}
-
-	// Round block height down to nearest 100 for consistency with batch querying
-	height := s.getCurrentHeight() / 100 * 100
 	sInfos, v, wV := s.Stakers.GetStakersNoCopy()
-	if height <= finalizedBlock || v <= finalizedVersion || wV <= finalizedWithdrawVersion {
-		s.Logger().Info("fetch delegators from beaconchain, no change in height(round to 100) or version, return latestChangesBytes", "height", height, "version", finalizedVersion, "withdrawVersion", finalizedWithdrawVersion)
-		return &types.PriceInfo{
+	// return zero price when there's no stakers
+	if len(sInfos) == 0 {
+		latestChangesBytes = fetchertypes.NSTZeroChanges
+		return &fetchertypes.PriceInfo{
 			Price: string(latestChangesBytes),
 			// combine height and versions as roundID in priceInfo
 			RoundID: fmt.Sprintf("%s|%s|%s", strconv.FormatUint(finalizedBlock, 10), strconv.FormatUint(finalizedVersion, 10), strconv.FormatUint(finalizedWithdrawVersion, 10)),
 		}, nil
-		//		return nil, nil
+	}
+	// Round block height down to nearest 100 for consistency with batch querying
+	height := s.getCurrentHeight() / 100 * 100
+
+	if height <= finalizedBlock || v <= finalizedVersion || wV <= finalizedWithdrawVersion {
+		s.Logger().Info("fetch delegators from beaconchain, no change in height(round to 100) or version, return latestChangesBytes", "height", height, "version", finalizedVersion, "withdrawVersion", finalizedWithdrawVersion)
+		return &fetchertypes.PriceInfo{
+			Price: string(latestChangesBytes),
+			// combine height and versions as roundID in priceInfo
+			RoundID: fmt.Sprintf("%s|%s|%s", strconv.FormatUint(finalizedBlock, 10), strconv.FormatUint(finalizedVersion, 10), strconv.FormatUint(finalizedWithdrawVersion, 10)),
+		}, nil
 	}
 
 	// TODO: 20 should be set as a value that less than fetching interval
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
-	delegators := []common.Address{}
-	delegator2Idx := make(map[common.Address]uint32)
+	capsules := []common.Address{}
+	capsule2Idx := make(map[common.Address]uint32)
 	for stakerIdx, sInfo := range sInfos {
-		// this should not happen
+		// oracle events now set Validators[0] as capsule address for BSC
 		if len(sInfo.Validators) != 1 {
-			s.Logger().Error("for bsc native restaker, one and only one valiators must be bonded to the staker")
+			s.Logger().Error("invalid staker validators length for bsc", "staker_index", stakerIdx, "validators_length", len(sInfo.Validators))
 			continue
 		}
-		addr := common.HexToAddress(sInfo.Validators[0])
-		delegators = append(delegators, addr)
-		delegator2Idx[addr] = stakerIdx
+		capAddr := common.HexToAddress(sInfo.Validators[0])
+		capsules = append(capsules, capAddr)
+		capsule2Idx[capAddr] = stakerIdx
 	}
-	grouped := make(map[common.Address][]common.Address)
-	jobs := make([]job, 0)
-	for _, d := range delegators {
-		if v, exists := s.cache.get(d); exists {
-			grouped[v] = append(grouped[v], d)
-		} else {
-			jobs = append(jobs, job{
-				kind:       jobKindFullScan,
-				delegators: []common.Address{d},
-				block:      height,
-			})
+
+	jobs := make([]job, 0, (len(capsules)+batchSize-1)/batchSize)
+	for aIdx := 0; aIdx < len(capsules); aIdx += batchSize {
+		bIdx := aIdx + batchSize
+		if bIdx > len(capsules) {
+			bIdx = len(capsules)
 		}
-	}
-	for v, ds := range grouped {
-		l := len(ds)
-		if l == 0 {
-			continue
-		}
-		aIdx := 0
-		for aIdx < l {
-			bIdx := aIdx + batchSize
-			if bIdx > l {
-				bIdx = l
-			}
-			jobs = append(jobs, job{
-				kind:       jobKindBatchDelegators,
-				credit:     v,
-				delegators: ds[aIdx:bIdx],
-				block:      height,
-			})
-			aIdx += batchSize
-		}
+		jobs = append(jobs, job{
+			kind:     jobKindBatchCapsules,
+			capsules: capsules[aIdx:bIdx],
+			block:    height,
+		})
 	}
 	res, err := s.pool.runBatch(ctx, jobs)
 	if err != nil {
 		return nil, err
 	}
 	changedStakerBalances := make([]*oracletypes.NSTKV, 0, len(sInfos))
-	for _, d := range delegators {
-		sIdx := delegator2Idx[d]
+	for _, capAddr := range capsules {
+		sIdx := capsule2Idx[capAddr]
 		sInfo := sInfos[sIdx]
-		if sInfo.Balance != res[d] || sInfo.WithdrawVersion > finalizedWithdrawVersion {
+		if sInfo.Balance != res[capAddr] || sInfo.WithdrawVersion > finalizedWithdrawVersion {
 			changedStakerBalances = append(changedStakerBalances, &oracletypes.NSTKV{
 				StakerIndex: sIdx,
-				Balance:     res[d],
+				Balance:     res[capAddr],
 			})
 		}
 	}
@@ -131,7 +118,7 @@ func (s *source) fetch(token string) (*fetchertypes.PriceInfo, error) {
 	finalizedVersion = v
 	finalizedWithdrawVersion = wV
 
-	return &types.PriceInfo{
+	return &fetchertypes.PriceInfo{
 		Price:   string(latestChangesBytes),
 		RoundID: fmt.Sprintf("%s|%s|%s", strconv.FormatUint(finalizedBlock, 10), strconv.FormatUint(v, 10), strconv.FormatUint(wV, 10)),
 	}, nil

--- a/fetcher/bsc/bsc_fetch.go
+++ b/fetcher/bsc/bsc_fetch.go
@@ -1,0 +1,142 @@
+package bsc
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/ethereum/go-ethereum/common"
+	oracletypes "github.com/imua-xyz/imuachain/x/oracle/types"
+	"github.com/imua-xyz/price-feeder/fetcher/types"
+	fetchertypes "github.com/imua-xyz/price-feeder/fetcher/types"
+	feedertypes "github.com/imua-xyz/price-feeder/types"
+)
+
+const batchSize = 100
+
+var (
+	finalizedBlock           uint64
+	finalizedVersion         uint64
+	finalizedWithdrawVersion uint64
+
+	latestChangesBytes = fetchertypes.NSTZeroChanges
+)
+
+func (s *source) fetch(token string) (*fetchertypes.PriceInfo, error) {
+	if fetchertypes.NSTToken(token) != fetchertypes.NativeTokenBSC {
+		return nil, feedertypes.ErrTokenNotSupported.Wrap(fmt.Sprintf("only support native-eth-restaking %s, got:%s", fetchertypes.NativeTokenBSC, token))
+	}
+
+	// Round block height down to nearest 100 for consistency with batch querying
+	height := s.getCurrentHeight() / 100 * 100
+	sInfos, v, wV := s.Stakers.GetStakersNoCopy()
+	if height <= finalizedBlock || v <= finalizedVersion || wV <= finalizedWithdrawVersion {
+		s.Logger().Info("fetch delegators from beaconchain, no change in height(round to 100) or version, return latestChangesBytes", "height", height, "version", finalizedVersion, "withdrawVersion", finalizedWithdrawVersion)
+		return &types.PriceInfo{
+			Price: string(latestChangesBytes),
+			// combine height and versions as roundID in priceInfo
+			RoundID: fmt.Sprintf("%s|%s|%s", strconv.FormatUint(finalizedBlock, 10), strconv.FormatUint(finalizedVersion, 10), strconv.FormatUint(finalizedWithdrawVersion, 10)),
+		}, nil
+		//		return nil, nil
+	}
+
+	// TODO: 20 should be set as a value that less than fetching interval
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	delegators := []common.Address{}
+	delegator2Idx := make(map[common.Address]uint32)
+	for stakerIdx, sInfo := range sInfos {
+		// this should not happen
+		if len(sInfo.Validators) != 1 {
+			s.Logger().Error("for bsc native restaker, one and only one valiators must be bonded to the staker")
+			continue
+		}
+		addr := common.HexToAddress(sInfo.Validators[0])
+		delegators = append(delegators, addr)
+		delegator2Idx[addr] = stakerIdx
+	}
+	grouped := make(map[common.Address][]common.Address)
+	jobs := make([]job, 0)
+	for _, d := range delegators {
+		if v, exists := s.cache.get(d); exists {
+			grouped[v] = append(grouped[v], d)
+		} else {
+			jobs = append(jobs, job{
+				kind:       jobKindFullScan,
+				delegators: []common.Address{d},
+				block:      height,
+			})
+		}
+	}
+	for v, ds := range grouped {
+		l := len(ds)
+		if l == 0 {
+			continue
+		}
+		aIdx := 0
+		for aIdx < l {
+			bIdx := aIdx + batchSize
+			if bIdx > l {
+				bIdx = l
+			}
+			jobs = append(jobs, job{
+				kind:       jobKindBatchDelegators,
+				credit:     v,
+				delegators: ds[aIdx:bIdx],
+				block:      height,
+			})
+			aIdx += batchSize
+		}
+	}
+	res, err := s.pool.runBatch(ctx, jobs)
+	if err != nil {
+		return nil, err
+	}
+	changedStakerBalances := make([]*oracletypes.NSTKV, 0, len(sInfos))
+	for _, d := range delegators {
+		sIdx := delegator2Idx[d]
+		sInfo := sInfos[sIdx]
+		if sInfo.Balance != res[d] || sInfo.WithdrawVersion > finalizedWithdrawVersion {
+			changedStakerBalances = append(changedStakerBalances, &oracletypes.NSTKV{
+				StakerIndex: sIdx,
+				Balance:     res[d],
+			})
+		}
+	}
+
+	if len(changedStakerBalances) > 0 {
+		s.Logger().Info("fetched delegator amounts from bsc, some amounts of delegators have changed")
+		sort.Slice(changedStakerBalances, func(i, j int) bool {
+			return changedStakerBalances[i].StakerIndex < changedStakerBalances[j].StakerIndex
+		})
+		nstBC := oracletypes.RawDataNST{
+			Version:           v,
+			WithdrawVersion:   wV,
+			NstBalanceChanges: changedStakerBalances,
+		}
+		bz, err := proto.Marshal(&nstBC)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal nstBalanceChanges, error:%w", err)
+		}
+		latestChangesBytes = bz
+	} else {
+		s.Logger().Info("fetched delegator amounts from bsc, all amounts remain unchanged")
+		latestChangesBytes = fetchertypes.NSTZeroChanges
+	}
+
+	finalizedBlock = height
+	finalizedVersion = v
+	finalizedWithdrawVersion = wV
+
+	return &types.PriceInfo{
+		Price:   string(latestChangesBytes),
+		RoundID: fmt.Sprintf("%s|%s|%s", strconv.FormatUint(finalizedBlock, 10), strconv.FormatUint(v, 10), strconv.FormatUint(wV, 10)),
+	}, nil
+}
+
+func (s *source) reload(config, token string) error {
+	return nil
+}

--- a/fetcher/bsc/bsc_fetch_test.go
+++ b/fetcher/bsc/bsc_fetch_test.go
@@ -1,0 +1,391 @@
+package bsc
+
+import (
+	"context"
+	"math/big"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cosmos/gogoproto/proto"
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	oracletypes "github.com/imua-xyz/imuachain/x/oracle/types"
+	nsttypes "github.com/imua-xyz/price-feeder/fetcher/nst/types"
+	fetchertypes "github.com/imua-xyz/price-feeder/fetcher/types"
+	feedertypes "github.com/imua-xyz/price-feeder/types"
+)
+
+type mockEthClient struct {
+	block uint64
+
+	multicallABI  abi.ABI
+	capsuleABI    abi.ABI
+	capsuleValues map[common.Address][2]*big.Int // pooled, locked
+
+	callCount int
+}
+
+func (m *mockEthClient) BlockNumber(ctx context.Context) (uint64, error) {
+	return m.block, nil
+}
+
+func (m *mockEthClient) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	m.callCount++
+	// We only expect multicall aggregate calls in these tests.
+	// Decode input to learn the target list order.
+	if len(msg.Data) < 4 {
+		return nil, nil
+	}
+	method := m.multicallABI.Methods["aggregate"]
+	args, err := method.Inputs.Unpack(msg.Data[4:])
+	if err != nil {
+		return nil, err
+	}
+	// args[0] is the tuple[] calls
+	callsV := args[0]
+
+	// Reflect over the slice of calls to extract .Target fields in order.
+	// Each element is a struct with fields Target and CallData.
+	rv := reflect.ValueOf(callsV)
+	returnData := make([][]byte, 0, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		item := rv.Index(i)
+		if item.Kind() == reflect.Pointer {
+			item = item.Elem()
+		}
+		target := item.FieldByName("Target").Interface().(common.Address)
+		val := m.capsuleValues[target]
+		pooled := val[0]
+		locked := val[1]
+		outBz, err := m.capsuleABI.Methods["getPooledAndLockedBNBs"].Outputs.Pack(pooled, locked)
+		if err != nil {
+			return nil, err
+		}
+		returnData = append(returnData, outBz)
+	}
+
+	// multicall aggregate outputs: (uint256 blockNumber, bytes[] returnData)
+	return method.Outputs.Pack(new(big.Int).SetUint64(m.block), returnData)
+}
+
+func TestBSCFetch_NoStakers_ReturnsZeroChanges(t *testing.T) {
+	// reset globals for isolation
+	finalizedBlock, finalizedVersion, finalizedWithdrawVersion = 0, 0, 0
+	latestChangesBytes = fetchertypes.NSTZeroChanges
+
+	logger := feedertypes.NewLogger(feedertypes.LogConf{})
+	s := &source{
+		Source: nsttypes.NewSource(logger, fetchertypes.Bsc, nil, "", func(string, string) error { return nil }),
+	}
+	// Empty stakers
+	s.SetNSTStakers(fetchertypes.StakerInfos{}, 1, 0)
+
+	pi, err := s.fetch(string(fetchertypes.NativeTokenBSC))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pi == nil {
+		t.Fatalf("expected price info, got nil")
+	}
+	if pi.Price != string(fetchertypes.NSTZeroChanges) {
+		t.Fatalf("expected NSTZeroChanges, got len=%d", len(pi.Price))
+	}
+}
+
+func TestBSCFetch_CapsuleOnly_MulticallProducesBalanceChanges(t *testing.T) {
+	// reset globals for isolation
+	finalizedBlock, finalizedVersion, finalizedWithdrawVersion = 0, 0, 0
+	latestChangesBytes = fetchertypes.NSTZeroChanges
+
+	logger := feedertypes.NewLogger(feedertypes.LogConf{})
+
+	mcABI, err := abi.JSON(strings.NewReader(multicallABIJSON))
+	if err != nil {
+		t.Fatalf("parse multicall abi: %v", err)
+	}
+	capABI, err := abi.JSON(strings.NewReader(capsuleABIJSON))
+	if err != nil {
+		t.Fatalf("parse capsule abi: %v", err)
+	}
+
+	c1 := common.HexToAddress("0x00000000000000000000000000000000000000c1")
+	c2 := common.HexToAddress("0x00000000000000000000000000000000000000c2")
+
+	mock := &mockEthClient{
+		block:        12345,
+		multicallABI: mcABI,
+		capsuleABI:   capABI,
+		capsuleValues: map[common.Address][2]*big.Int{
+			c1: {big.NewInt(1e9), big.NewInt(2e9)}, // total 3e9 => 3 gwei
+			c2: {big.NewInt(0), big.NewInt(0)},     // 0
+		},
+	}
+
+	s := &source{
+		Source:        nsttypes.NewSource(logger, fetchertypes.Bsc, nil, "", func(string, string) error { return nil }),
+		client:        mock,
+		multicallAddr: common.HexToAddress("0x00000000000000000000000000000000000000aa"),
+		multicallABI:  mcABI,
+		capsuleABI:    capABI,
+	}
+	s.pool = startNewWorkerPool(s, workerPoolConfig{numWorkers: 1, jobBuffer: 10})
+
+	// staker0 old balance 0 -> new 3
+	// staker1 old balance 1 -> new 0
+	sInfos := fetchertypes.StakerInfos{
+		0: &fetchertypes.StakerInfo{Validators: []string{c1.Hex()}, Balance: 0},
+		1: &fetchertypes.StakerInfo{Validators: []string{c2.Hex()}, Balance: 1},
+	}
+	s.SetNSTStakers(sInfos, 1, 0)
+
+	pi, err := s.fetch(string(fetchertypes.NativeTokenBSC))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var raw oracletypes.RawDataNST
+	if err := proto.Unmarshal([]byte(pi.Price), &raw); err != nil {
+		t.Fatalf("unmarshal RawDataNST: %v", err)
+	}
+	if raw.Version != 1 {
+		t.Fatalf("expected version 1, got %d", raw.Version)
+	}
+	if len(raw.NstBalanceChanges) != 2 {
+		t.Fatalf("expected 2 balance changes, got %d", len(raw.NstBalanceChanges))
+	}
+	// Expect staker0=3, staker1=0
+	if raw.NstBalanceChanges[0].StakerIndex != 0 || raw.NstBalanceChanges[0].Balance != 3 {
+		t.Fatalf("unexpected change[0]: %+v", raw.NstBalanceChanges[0])
+	}
+	if raw.NstBalanceChanges[1].StakerIndex != 1 || raw.NstBalanceChanges[1].Balance != 0 {
+		t.Fatalf("unexpected change[1]: %+v", raw.NstBalanceChanges[1])
+	}
+}
+
+func TestBSCFetch_OnlyChangedStakerIncluded(t *testing.T) {
+	// reset globals for isolation
+	finalizedBlock, finalizedVersion, finalizedWithdrawVersion = 0, 0, 0
+	latestChangesBytes = fetchertypes.NSTZeroChanges
+
+	logger := feedertypes.NewLogger(feedertypes.LogConf{})
+
+	mcABI, err := abi.JSON(strings.NewReader(multicallABIJSON))
+	if err != nil {
+		t.Fatalf("parse multicall abi: %v", err)
+	}
+	capABI, err := abi.JSON(strings.NewReader(capsuleABIJSON))
+	if err != nil {
+		t.Fatalf("parse capsule abi: %v", err)
+	}
+
+	c1 := common.HexToAddress("0x00000000000000000000000000000000000000c1")
+	c2 := common.HexToAddress("0x00000000000000000000000000000000000000c2")
+
+	// c1 total 5 gwei, c2 total 7 gwei
+	mock := &mockEthClient{
+		block:        12300,
+		multicallABI: mcABI,
+		capsuleABI:   capABI,
+		capsuleValues: map[common.Address][2]*big.Int{
+			c1: {big.NewInt(5e9), big.NewInt(0)},
+			c2: {big.NewInt(7e9), big.NewInt(0)},
+		},
+	}
+
+	s := &source{
+		Source:        nsttypes.NewSource(logger, fetchertypes.Bsc, nil, "", func(string, string) error { return nil }),
+		client:        mock,
+		multicallAddr: common.HexToAddress("0x00000000000000000000000000000000000000aa"),
+		multicallABI:  mcABI,
+		capsuleABI:    capABI,
+	}
+	s.pool = startNewWorkerPool(s, workerPoolConfig{numWorkers: 1, jobBuffer: 10})
+
+	// staker0 old 5 -> new 5 (unchanged), staker1 old 1 -> new 7 (changed)
+	sInfos := fetchertypes.StakerInfos{
+		0: &fetchertypes.StakerInfo{Validators: []string{c1.Hex()}, Balance: 5, WithdrawVersion: 0},
+		1: &fetchertypes.StakerInfo{Validators: []string{c2.Hex()}, Balance: 1, WithdrawVersion: 0},
+	}
+	s.SetNSTStakers(sInfos, 1, 0)
+
+	pi, err := s.fetch(string(fetchertypes.NativeTokenBSC))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var raw oracletypes.RawDataNST
+	if err := proto.Unmarshal([]byte(pi.Price), &raw); err != nil {
+		t.Fatalf("unmarshal RawDataNST: %v", err)
+	}
+	if len(raw.NstBalanceChanges) != 1 {
+		t.Fatalf("expected 1 balance change, got %d", len(raw.NstBalanceChanges))
+	}
+	if raw.NstBalanceChanges[0].StakerIndex != 1 || raw.NstBalanceChanges[0].Balance != 7 {
+		t.Fatalf("unexpected change: %+v", raw.NstBalanceChanges[0])
+	}
+}
+
+func TestBSCFetch_NoChangeWhenHeightAndVersionsUnchanged_ReturnsCached(t *testing.T) {
+	// reset globals for isolation
+	finalizedBlock, finalizedVersion, finalizedWithdrawVersion = 12300, 1, 5
+	latestChangesBytes = []byte("cached-bytes")
+
+	logger := feedertypes.NewLogger(feedertypes.LogConf{})
+
+	mcABI, err := abi.JSON(strings.NewReader(multicallABIJSON))
+	if err != nil {
+		t.Fatalf("parse multicall abi: %v", err)
+	}
+	capABI, err := abi.JSON(strings.NewReader(capsuleABIJSON))
+	if err != nil {
+		t.Fatalf("parse capsule abi: %v", err)
+	}
+
+	mock := &mockEthClient{
+		block:        12300,
+		multicallABI: mcABI,
+		capsuleABI:   capABI,
+		capsuleValues: map[common.Address][2]*big.Int{
+			common.HexToAddress("0x00000000000000000000000000000000000000c1"): {big.NewInt(0), big.NewInt(0)},
+		},
+	}
+
+	s := &source{
+		Source:        nsttypes.NewSource(logger, fetchertypes.Bsc, nil, "", func(string, string) error { return nil }),
+		client:        mock,
+		multicallAddr: common.HexToAddress("0x00000000000000000000000000000000000000aa"),
+		multicallABI:  mcABI,
+		capsuleABI:    capABI,
+	}
+	s.pool = startNewWorkerPool(s, workerPoolConfig{numWorkers: 1, jobBuffer: 10})
+
+	// version=1, withdrawVersion=5 match finalized ones, height equals finalizedBlock
+	sInfos := fetchertypes.StakerInfos{
+		0: &fetchertypes.StakerInfo{Validators: []string{"0x00000000000000000000000000000000000000c1"}, Balance: 0, WithdrawVersion: 0},
+	}
+	s.SetNSTStakers(sInfos, 1, 5)
+
+	pi, err := s.fetch(string(fetchertypes.NativeTokenBSC))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pi.Price != string(latestChangesBytes) {
+		t.Fatalf("expected cached bytes, got %q", pi.Price)
+	}
+	if mock.callCount != 0 {
+		t.Fatalf("expected no CallContract when unchanged, got %d", mock.callCount)
+	}
+}
+
+func TestBSCFetch_WithdrawVersionForcesInclusionEvenIfBalanceUnchanged(t *testing.T) {
+	// reset globals for isolation
+	finalizedBlock, finalizedVersion, finalizedWithdrawVersion = 0, 0, 1
+	latestChangesBytes = fetchertypes.NSTZeroChanges
+
+	logger := feedertypes.NewLogger(feedertypes.LogConf{})
+
+	mcABI, err := abi.JSON(strings.NewReader(multicallABIJSON))
+	if err != nil {
+		t.Fatalf("parse multicall abi: %v", err)
+	}
+	capABI, err := abi.JSON(strings.NewReader(capsuleABIJSON))
+	if err != nil {
+		t.Fatalf("parse capsule abi: %v", err)
+	}
+
+	c1 := common.HexToAddress("0x00000000000000000000000000000000000000c1")
+	mock := &mockEthClient{
+		block:        12300,
+		multicallABI: mcABI,
+		capsuleABI:   capABI,
+		capsuleValues: map[common.Address][2]*big.Int{
+			c1: {big.NewInt(5e9), big.NewInt(0)}, // 5 gwei
+		},
+	}
+
+	s := &source{
+		Source:        nsttypes.NewSource(logger, fetchertypes.Bsc, nil, "", func(string, string) error { return nil }),
+		client:        mock,
+		multicallAddr: common.HexToAddress("0x00000000000000000000000000000000000000aa"),
+		multicallABI:  mcABI,
+		capsuleABI:    capABI,
+	}
+	s.pool = startNewWorkerPool(s, workerPoolConfig{numWorkers: 1, jobBuffer: 10})
+
+	// Balance unchanged at 5, but withdrawVersion increased beyond finalizedWithdrawVersion => should include.
+	sInfos := fetchertypes.StakerInfos{
+		0: &fetchertypes.StakerInfo{Validators: []string{c1.Hex()}, Balance: 5, WithdrawVersion: 2},
+	}
+	s.SetNSTStakers(sInfos, 1, 2)
+
+	pi, err := s.fetch(string(fetchertypes.NativeTokenBSC))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var raw oracletypes.RawDataNST
+	if err := proto.Unmarshal([]byte(pi.Price), &raw); err != nil {
+		t.Fatalf("unmarshal RawDataNST: %v", err)
+	}
+	if len(raw.NstBalanceChanges) != 1 {
+		t.Fatalf("expected 1 balance change, got %d", len(raw.NstBalanceChanges))
+	}
+	if raw.NstBalanceChanges[0].StakerIndex != 0 || raw.NstBalanceChanges[0].Balance != 5 {
+		t.Fatalf("unexpected change: %+v", raw.NstBalanceChanges[0])
+	}
+}
+
+func TestBSCFetch_VersionIncreasesButNoOtherChanges_ReturnsZeroChanges(t *testing.T) {
+	// reset globals for isolation
+	finalizedBlock, finalizedVersion, finalizedWithdrawVersion = 12300, 1, 5
+	latestChangesBytes = fetchertypes.NSTZeroChanges
+
+	logger := feedertypes.NewLogger(feedertypes.LogConf{})
+
+	mcABI, err := abi.JSON(strings.NewReader(multicallABIJSON))
+	if err != nil {
+		t.Fatalf("parse multicall abi: %v", err)
+	}
+	capABI, err := abi.JSON(strings.NewReader(capsuleABIJSON))
+	if err != nil {
+		t.Fatalf("parse capsule abi: %v", err)
+	}
+
+	c1 := common.HexToAddress("0x00000000000000000000000000000000000000c1")
+	mock := &mockEthClient{
+		block:        12300, // same height bucket
+		multicallABI: mcABI,
+		capsuleABI:   capABI,
+		capsuleValues: map[common.Address][2]*big.Int{
+			c1: {big.NewInt(5e9), big.NewInt(0)}, // 5 gwei, unchanged
+		},
+	}
+
+	s := &source{
+		Source:        nsttypes.NewSource(logger, fetchertypes.Bsc, nil, "", func(string, string) error { return nil }),
+		client:        mock,
+		multicallAddr: common.HexToAddress("0x00000000000000000000000000000000000000aa"),
+		multicallABI:  mcABI,
+		capsuleABI:    capABI,
+	}
+	s.pool = startNewWorkerPool(s, workerPoolConfig{numWorkers: 1, jobBuffer: 10})
+
+	// version increased (2 > finalizedVersion), but wV unchanged and balance unchanged => expect zero changes
+	sInfos := fetchertypes.StakerInfos{
+		0: &fetchertypes.StakerInfo{Validators: []string{c1.Hex()}, Balance: 5, WithdrawVersion: 5},
+	}
+	s.SetNSTStakers(sInfos, 2, 5)
+
+	pi, err := s.fetch(string(fetchertypes.NativeTokenBSC))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pi.Price != string(fetchertypes.NSTZeroChanges) {
+		t.Fatalf("expected NSTZeroChanges, got %q", pi.Price)
+	}
+	if mock.callCount == 0 {
+		t.Fatalf("expected multicall to be executed when version increased")
+	}
+}

--- a/fetcher/bsc/types.go
+++ b/fetcher/bsc/types.go
@@ -1,9 +1,12 @@
 package bsc
 
 import (
+	"context"
 	"fmt"
+	"math/big"
 	"strings"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -67,7 +70,7 @@ type config struct {
 
 type source struct {
 	*nsttypes.Source
-	client *ethclient.Client
+	client ethClientInf
 
 	multicallAddr common.Address
 
@@ -75,6 +78,12 @@ type source struct {
 	capsuleABI   abi.ABI
 
 	pool *workerPool
+}
+
+// ethClientInf allows mocking eth client in tests.
+type ethClientInf interface {
+	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+	BlockNumber(ctx context.Context) (uint64, error)
 }
 
 func init() {

--- a/fetcher/bsc/types.go
+++ b/fetcher/bsc/types.go
@@ -1,11 +1,8 @@
 package bsc
 
 import (
-	"errors"
 	"fmt"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -41,45 +38,13 @@ const (
 	}
   ]`
 
-	stakeCreditABIJSONPooled = `[
+	capsuleABIJSON = `[
   {
-    "inputs": [
-      {"internalType": "address","name": "account","type": "address"}
-    ],
-    "name": "getPooledBNB",
+    "inputs": [],
+    "name": "getPooledAndLockedBNBs",
     "outputs": [
-      {"internalType": "uint256","name": "", "type": "uint256"}
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  }
-]`
-	stakeCreditABIJSONLocked = `[
-  {
-    "inputs": [
-      {"internalType": "address","name": "delegator","type": "address"},
-      {"internalType": "uint256","name": "number","type": "uint256"}
-    ],
-    "name": "lockedBNBs",
-    "outputs": [
-      {"internalType": "uint256","name": "", "type": "uint256"}
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  }
-]`
-
-	stakeHubABIJSON = `[
-  {
-    "inputs": [
-      {"internalType": "uint256","name": "offset","type": "uint256"},
-      {"internalType": "uint256","name": "limit","type": "uint256"}
-    ],
-    "name": "getValidators",
-    "outputs": [
-      {"internalType": "address[]","name": "operatorAddrs","type": "address[]"},
-      {"internalType": "address[]","name": "creditAddrs","type": "address[]"},
-      {"internalType": "uint256","name": "totalLength","type": "uint256"}
+      {"internalType": "uint256","name": "pooledBNB","type": "uint256"},
+      {"internalType": "uint256","name": "lockedBNB","type": "uint256"}
     ],
     "stateMutability": "view",
     "type": "function"
@@ -90,44 +55,14 @@ const (
 var (
 	logger        feedertypes.LoggerInf
 	defaultSource *source
-
-	errNoValidatorFound = errors.New("delegator not bonded to any validator")
-	errInvalidJob       = errors.New("invalid worker job")
-
-	// errBig is expected to be used as a helper, and should be constructed where needed,
-	// since d and amt are not in scope here. Remove it from global scope.
+	errInvalidJob = fmt.Errorf("invalid worker job")
 )
 
 type config struct {
-	MuilticallAddr string        `yaml:"multicall_addr"`
-	StakeHubAddr   string        `yaml:"stake_hub_addr"`
-	CacheTTL       time.Duration `yaml:"cache_ttl"`
+	MuilticallAddr string `yaml:"multicall_addr"`
 	URLs           struct {
 		Bsc string `yaml:"bsc"`
 	} `yaml:"urls"`
-	// NumWorkers     int `yaml:"num_workers"`
-	// JobBuffer      int `yaml:"job_buffer"`
-}
-
-type validatorInfo struct {
-	Operator       common.Address
-	CreditContract common.Address
-}
-
-type cacheEntry struct {
-	ValidatorCredit common.Address // credit contract address
-	// ExpireAt        time.Time
-}
-
-type validatorSet struct {
-	mu   sync.RWMutex
-	vals []validatorInfo
-}
-
-type delegatorCache struct {
-	// TODO: add cap, and clear expired entries when hit cap
-	//	ttl   time.Duration
-	store sync.Map
 }
 
 type source struct {
@@ -135,78 +70,11 @@ type source struct {
 	client *ethclient.Client
 
 	multicallAddr common.Address
-	stakeHubAddr  common.Address
-
-	// ttl time.Duration
 
 	multicallABI abi.ABI
-	pooledABI    abi.ABI
-	lockedABI    abi.ABI
-	stakeHubABI  abi.ABI
-
-	//	mu    sync.RWMutex
-	// cache map[common.Address]cacheEntry
-	cache *delegatorCache
-	//	validators []validatorInfo // operator + creditContract
-	validators *validatorSet
+	capsuleABI   abi.ABI
 
 	pool *workerPool
-}
-
-func (d *delegatorCache) set(addr, v common.Address) {
-	d.store.Store(addr, cacheEntry{
-		ValidatorCredit: v,
-		//	ExpireAt:        time.Now().Add(d.ttl),
-	})
-}
-
-func (d *delegatorCache) get(delegator common.Address) (common.Address, bool) {
-	v, ok := d.store.Load(delegator)
-	if !ok {
-		return common.Address{}, false
-	}
-	entry := v.(cacheEntry)
-	// if time.Now().After(entry.ExpireAt) || (entry.ValidatorCredit == common.Address{}) {
-	if entry.ValidatorCredit == (common.Address{}) {
-		return common.Address{}, false
-	}
-	return entry.ValidatorCredit, true
-}
-
-func (d *delegatorCache) delete(addr common.Address) {
-	d.store.Delete(addr)
-}
-
-// func newDelegatorCache(ttl time.Duration) *delegatorCache {
-func newDelegatorCache() *delegatorCache {
-	//	if ttl <= 0 {
-	//		ttl = 24 * time.Hour
-	//	}
-	return &delegatorCache{
-		//	ttl:   ttl,
-		store: sync.Map{},
-	}
-}
-
-func (vs *validatorSet) getValidators() []validatorInfo {
-	vs.mu.RLock()
-	cpy := make([]validatorInfo, len(vs.vals))
-	copy(cpy, vs.vals)
-	vs.mu.RUnlock()
-	return cpy
-}
-
-func (vs *validatorSet) setValidators(vals []validatorInfo) {
-	vs.mu.Lock()
-	vs.vals = make([]validatorInfo, len(vals))
-	copy(vs.vals, vals)
-	vs.mu.Unlock()
-}
-func newValidatorSet() *validatorSet {
-	return &validatorSet{
-		mu:   sync.RWMutex{},
-		vals: make([]validatorInfo, 0, 100),
-	}
 }
 
 func init() {
@@ -230,19 +98,9 @@ func initBSC(cfgPath string, l feedertypes.LoggerInf) (fetchertypes.SourceInf, e
 		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse multicall ABI, error:%v", err))
 	}
 
-	pooledABI, err := abi.JSON(strings.NewReader(stakeCreditABIJSONPooled))
+	capsuleABI, err := abi.JSON(strings.NewReader(capsuleABIJSON))
 	if err != nil {
-		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse stake credit ABI, error:%v", err))
-	}
-
-	lockedABI, err := abi.JSON(strings.NewReader(stakeCreditABIJSONLocked))
-	if err != nil {
-		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse stake credit ABI, error:%v", err))
-	}
-
-	stakeHubABI, err := abi.JSON(strings.NewReader(stakeHubABIJSON))
-	if err != nil {
-		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse stake hub ABI, error:%v", err))
+		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse capsule ABI, error:%v", err))
 	}
 
 	client, err := ethclient.Dial(cfg.URLs.Bsc)
@@ -256,13 +114,8 @@ func initBSC(cfgPath string, l feedertypes.LoggerInf) (fetchertypes.SourceInf, e
 		Source:        nsttypes.NewSource(logger, fetchertypes.Bsc, defaultSource.fetch, cfgPath, defaultSource.reload),
 		client:        client,
 		multicallAddr: common.HexToAddress(cfg.MuilticallAddr),
-		stakeHubAddr:  common.HexToAddress(cfg.StakeHubAddr),
 		multicallABI:  multicallABI,
-		pooledABI:     pooledABI,
-		lockedABI:     lockedABI,
-		stakeHubABI:   stakeHubABI,
-		cache:         newDelegatorCache(),
-		validators:    newValidatorSet(),
+		capsuleABI:    capsuleABI,
 		pool: startNewWorkerPool(defaultSource, workerPoolConfig{
 			numWorkers: 10,
 			jobBuffer:  100,

--- a/fetcher/bsc/types.go
+++ b/fetcher/bsc/types.go
@@ -1,0 +1,273 @@
+package bsc
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	nsttypes "github.com/imua-xyz/price-feeder/fetcher/nst/types"
+	fetchertypes "github.com/imua-xyz/price-feeder/fetcher/types"
+	feedertypes "github.com/imua-xyz/price-feeder/types"
+)
+
+const (
+	envConf = "oracle_env_bsc.yaml"
+
+	multicallABIJSON = `[
+	{
+	  "inputs": [
+		{
+		  "components": [
+			{"internalType": "address","name": "target","type": "address"},
+			{"internalType": "bytes","name": "callData","type": "bytes"}
+		  ],
+		  "internalType": "struct Call[]",
+		  "name": "calls",
+		  "type": "tuple[]"
+		}
+	  ],
+	  "name": "aggregate",
+	  "outputs": [
+		{"internalType": "uint256","name": "blockNumber","type": "uint256"},
+		{"internalType": "bytes[]","name": "returnData","type": "bytes[]"}
+	  ],
+	  "stateMutability": "nonpayable",
+	  "type": "function"
+	}
+  ]`
+
+	stakeCreditABIJSONPooled = `[
+  {
+    "inputs": [
+      {"internalType": "address","name": "account","type": "address"}
+    ],
+    "name": "getPooledBNB",
+    "outputs": [
+      {"internalType": "uint256","name": "", "type": "uint256"}
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]`
+	stakeCreditABIJSONLocked = `[
+  {
+    "inputs": [
+      {"internalType": "address","name": "delegator","type": "address"},
+      {"internalType": "uint256","name": "number","type": "uint256"}
+    ],
+    "name": "lockedBNBs",
+    "outputs": [
+      {"internalType": "uint256","name": "", "type": "uint256"}
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]`
+
+	stakeHubABIJSON = `[
+  {
+    "inputs": [
+      {"internalType": "uint256","name": "offset","type": "uint256"},
+      {"internalType": "uint256","name": "limit","type": "uint256"}
+    ],
+    "name": "getValidators",
+    "outputs": [
+      {"internalType": "address[]","name": "operatorAddrs","type": "address[]"},
+      {"internalType": "address[]","name": "creditAddrs","type": "address[]"},
+      {"internalType": "uint256","name": "totalLength","type": "uint256"}
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]`
+)
+
+var (
+	logger        feedertypes.LoggerInf
+	defaultSource *source
+
+	errNoValidatorFound = errors.New("delegator not bonded to any validator")
+	errInvalidJob       = errors.New("invalid worker job")
+
+	// errBig is expected to be used as a helper, and should be constructed where needed,
+	// since d and amt are not in scope here. Remove it from global scope.
+)
+
+type config struct {
+	MuilticallAddr string        `yaml:"multicall_addr"`
+	StakeHubAddr   string        `yaml:"stake_hub_addr"`
+	CacheTTL       time.Duration `yaml:"cache_ttl"`
+	URLs           struct {
+		Bsc string `yaml:"bsc"`
+	} `yaml:"urls"`
+	// NumWorkers     int `yaml:"num_workers"`
+	// JobBuffer      int `yaml:"job_buffer"`
+}
+
+type validatorInfo struct {
+	Operator       common.Address
+	CreditContract common.Address
+}
+
+type cacheEntry struct {
+	ValidatorCredit common.Address // credit contract address
+	// ExpireAt        time.Time
+}
+
+type validatorSet struct {
+	mu   sync.RWMutex
+	vals []validatorInfo
+}
+
+type delegatorCache struct {
+	// TODO: add cap, and clear expired entries when hit cap
+	//	ttl   time.Duration
+	store sync.Map
+}
+
+type source struct {
+	*nsttypes.Source
+	client *ethclient.Client
+
+	multicallAddr common.Address
+	stakeHubAddr  common.Address
+
+	// ttl time.Duration
+
+	multicallABI abi.ABI
+	pooledABI    abi.ABI
+	lockedABI    abi.ABI
+	stakeHubABI  abi.ABI
+
+	//	mu    sync.RWMutex
+	// cache map[common.Address]cacheEntry
+	cache *delegatorCache
+	//	validators []validatorInfo // operator + creditContract
+	validators *validatorSet
+
+	pool *workerPool
+}
+
+func (d *delegatorCache) set(addr, v common.Address) {
+	d.store.Store(addr, cacheEntry{
+		ValidatorCredit: v,
+		//	ExpireAt:        time.Now().Add(d.ttl),
+	})
+}
+
+func (d *delegatorCache) get(delegator common.Address) (common.Address, bool) {
+	v, ok := d.store.Load(delegator)
+	if !ok {
+		return common.Address{}, false
+	}
+	entry := v.(cacheEntry)
+	// if time.Now().After(entry.ExpireAt) || (entry.ValidatorCredit == common.Address{}) {
+	if entry.ValidatorCredit == (common.Address{}) {
+		return common.Address{}, false
+	}
+	return entry.ValidatorCredit, true
+}
+
+func (d *delegatorCache) delete(addr common.Address) {
+	d.store.Delete(addr)
+}
+
+// func newDelegatorCache(ttl time.Duration) *delegatorCache {
+func newDelegatorCache() *delegatorCache {
+	//	if ttl <= 0 {
+	//		ttl = 24 * time.Hour
+	//	}
+	return &delegatorCache{
+		//	ttl:   ttl,
+		store: sync.Map{},
+	}
+}
+
+func (vs *validatorSet) getValidators() []validatorInfo {
+	vs.mu.RLock()
+	cpy := make([]validatorInfo, len(vs.vals))
+	copy(cpy, vs.vals)
+	vs.mu.RUnlock()
+	return cpy
+}
+
+func (vs *validatorSet) setValidators(vals []validatorInfo) {
+	vs.mu.Lock()
+	vs.vals = make([]validatorInfo, len(vals))
+	copy(vs.vals, vals)
+	vs.mu.Unlock()
+}
+func newValidatorSet() *validatorSet {
+	return &validatorSet{
+		mu:   sync.RWMutex{},
+		vals: make([]validatorInfo, 0, 100),
+	}
+}
+
+func init() {
+	fetchertypes.SourceInitializers[fetchertypes.Bsc] = initBSC
+}
+
+func initBSC(cfgPath string, l feedertypes.LoggerInf) (fetchertypes.SourceInf, error) {
+	if logger = l; logger == nil {
+		if logger = feedertypes.GetLogger("fetcher_bsc"); logger == nil {
+			return nil, feedertypes.ErrInitFail.Wrap("logger is not initialized")
+		}
+	}
+
+	cfg, err := nsttypes.ParseConfig[config](cfgPath, envConf)
+	if err != nil {
+		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse config, error:%v", err))
+	}
+
+	multicallABI, err := abi.JSON(strings.NewReader(multicallABIJSON))
+	if err != nil {
+		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse multicall ABI, error:%v", err))
+	}
+
+	pooledABI, err := abi.JSON(strings.NewReader(stakeCreditABIJSONPooled))
+	if err != nil {
+		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse stake credit ABI, error:%v", err))
+	}
+
+	lockedABI, err := abi.JSON(strings.NewReader(stakeCreditABIJSONLocked))
+	if err != nil {
+		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse stake credit ABI, error:%v", err))
+	}
+
+	stakeHubABI, err := abi.JSON(strings.NewReader(stakeHubABIJSON))
+	if err != nil {
+		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse stake hub ABI, error:%v", err))
+	}
+
+	client, err := ethclient.Dial(cfg.URLs.Bsc)
+	if err != nil {
+		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to dial BSC, error:%v", err))
+	}
+
+	defaultSource = &source{}
+
+	*defaultSource = source{
+		Source:        nsttypes.NewSource(logger, fetchertypes.Bsc, defaultSource.fetch, cfgPath, defaultSource.reload),
+		client:        client,
+		multicallAddr: common.HexToAddress(cfg.MuilticallAddr),
+		stakeHubAddr:  common.HexToAddress(cfg.StakeHubAddr),
+		multicallABI:  multicallABI,
+		pooledABI:     pooledABI,
+		lockedABI:     lockedABI,
+		stakeHubABI:   stakeHubABI,
+		cache:         newDelegatorCache(),
+		validators:    newValidatorSet(),
+		pool: startNewWorkerPool(defaultSource, workerPoolConfig{
+			numWorkers: 10,
+			jobBuffer:  100,
+		}),
+	}
+
+	return defaultSource, nil
+}

--- a/fetcher/bsc/workers.go
+++ b/fetcher/bsc/workers.go
@@ -1,0 +1,359 @@
+package bsc
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type jobKind int
+
+const (
+	jobKindBatchDelegators jobKind = iota
+	jobKindFullScan
+
+// maxConcurrency = 256
+// // max concurrency set from config
+// concurrency = 0
+)
+
+type workerLevel struct {
+	workers int
+	base    int // base threshold for initial assignment
+	up      int // threshold to scale up from this level
+	down    int // threshold to scale down to this level
+}
+
+var workerLevels = []workerLevel{
+	{10, 2000, 2100, 1900},
+	{30, 6000, 6100, 5900},
+	{50, 10000, 10100, 9900},
+	{70, 0, 0, 0}, // no upper limit
+}
+
+type scannerInf interface {
+	batchQueryCreditForDelegators(ctx context.Context, credit common.Address, delegators []common.Address, blockNumber *big.Int) (map[common.Address]*big.Int, error)
+	fullScan(ctx context.Context, delegator common.Address, blockNumber *big.Int) (creditAddr common.Address, pooledBNB, lockedBNB *big.Int, err error)
+	refreshValidators() (updated bool, err error)
+}
+
+type job struct {
+	kind       jobKind
+	block      uint64
+	credit     common.Address
+	delegators []common.Address
+	resultCh   chan result
+}
+
+type result struct {
+	amounts map[common.Address]*big.Int
+	// amounts     map[common.Address]uint64
+	err error
+	// needRefresh []common.Address
+}
+
+// TODO: Since updating delegator balances is mostly IO-bound, a fixed number of workers is used. A semaphore limits the concurrency level, avoiding dynamic worker count changes.
+type workerPool struct {
+	resizing atomic.Bool
+	//	lock    sync.Mutex
+	scanner scannerInf
+	ctx     context.Context
+	cancel  context.CancelFunc
+	//	wg            sync.WaitGroup
+	jobs chan job
+	// results     chan result
+	active      atomic.Int32
+	stopWorkers chan chan struct{}
+	// confirmedStop chan struct{}
+}
+
+type workerPoolConfig struct {
+	numWorkers int
+	jobBuffer  int
+}
+
+// startNewWorkerPool starts a new worker pool with the given number of workers
+func startNewWorkerPool(scanner scannerInf, cfg workerPoolConfig) *workerPool {
+	ctx, cancel := context.WithCancel(context.Background())
+	pool := &workerPool{
+		jobs:        make(chan job, cfg.jobBuffer),
+		scanner:     scanner,
+		ctx:         ctx,
+		cancel:      cancel,
+		stopWorkers: make(chan chan struct{}, cfg.numWorkers),
+	}
+	//	for i := 0; i < cfg.numWorkers; i++ {
+	//		pool.spawnWorker()
+	//	}
+	if !pool.start(cfg.numWorkers) {
+		// TODO: handle error (safe for now since the wokerpool is set up on beginning of the program)
+		panic("failed to start worker pool")
+	}
+	return pool
+}
+
+func (wp *workerPool) start(num int) bool {
+	// avoid resizing during start/spawning
+	if !wp.resizing.CompareAndSwap(false, true) {
+		return false
+	}
+	for i := 0; i < num; i++ {
+		wp.spawnWorker()
+	}
+	wp.resizing.Store(false)
+	return true
+}
+
+func (wp *workerPool) stop() {
+	wp.resize(0)
+}
+
+func (wp *workerPool) spawnWorker() {
+	wp.active.Add(1)
+	go func() {
+		defer wp.active.Add(-1)
+		for {
+			select {
+			case j := <-wp.jobs:
+				ctx, cancel := context.WithTimeout(wp.ctx, 5*time.Second)
+				res := wp.handleJob(ctx, j)
+				cancel()
+				j.resultCh <- res
+			case ack := <-wp.stopWorkers:
+				ack <- struct{}{}
+				return
+			}
+		}
+	}()
+}
+
+// handleJob processes a job in the worker goroutine
+func (wp *workerPool) handleJob(ctx context.Context, j job) result {
+	switch j.kind {
+	case jobKindBatchDelegators:
+		blockNumber := new(big.Int).SetUint64(j.block)
+		amounts, err := wp.scanner.batchQueryCreditForDelegators(ctx, j.credit, j.delegators, blockNumber)
+		return result{
+			amounts: amounts,
+			err:     err,
+		}
+	case jobKindFullScan:
+		if len(j.delegators) != 1 {
+			return result{err: errInvalidJob}
+		}
+		d := j.delegators[0]
+		blockNumber := new(big.Int).SetUint64(j.block)
+		_, pooledBNB, lockedBNB, err := wp.scanner.fullScan(ctx, d, blockNumber)
+		if err != nil {
+			if err == errNoValidatorFound {
+				return result{
+					amounts: map[common.Address]*big.Int{
+						d: big.NewInt(0),
+					},
+					err: nil,
+				}
+			}
+			return result{
+				err: err,
+			}
+		}
+		total := new(big.Int).Add(pooledBNB, lockedBNB)
+		return result{
+			amounts: map[common.Address]*big.Int{d: total},
+			err:     nil,
+		}
+	default:
+		return result{
+			err: errInvalidJob,
+		}
+	}
+}
+
+// resize adjusts the number of workers based on job count with hysteresis buffer
+// If numJobs is 0, it will stop all workers
+func (wp *workerPool) resize(numJobs int) bool {
+	if !wp.resizing.CompareAndSwap(false, true) {
+		return false
+	}
+	defer wp.resizing.Store(false)
+
+	var targetWorkers int
+	if numJobs == 0 {
+		targetWorkers = 0
+	} else {
+		targetWorkers = wp.calculateTargetWorkers(numJobs)
+	}
+
+	currentWorkers := int(wp.active.Load())
+	delta := targetWorkers - currentWorkers
+	switch {
+	case delta == 0:
+		// return true
+		// spaw new active workers
+	case delta > 0:
+		for delta > 0 {
+			wp.spawnWorker()
+			delta--
+		}
+		// stop some active workers to reduce the count
+	case delta < 0:
+		delta *= -1
+		ack := make(chan struct{}, delta)
+		for i := 0; i < delta; i++ {
+			wp.stopWorkers <- ack
+		}
+		for range ack {
+			delta--
+			if delta <= 0 {
+				close(ack)
+				// return true
+				break
+			}
+		}
+	}
+	return true
+}
+
+// calculateTargetWorkers determines the target worker count based on current state and job count
+// Uses hysteresis buffer to prevent frequent resizing
+func (wp *workerPool) calculateTargetWorkers(numJobs int) int {
+	currentWorkers := int(wp.active.Load())
+
+	// Find current level index
+	currentIdx := -1
+	for i, l := range workerLevels {
+		if l.workers == currentWorkers {
+			currentIdx = i
+			break
+		}
+	}
+
+	// Unknown state: find appropriate level from job count (small to large)
+	if currentIdx == -1 {
+		for i := 0; i < len(workerLevels)-1; i++ {
+			if numJobs <= workerLevels[i].base {
+				return workerLevels[i].workers
+			}
+		}
+		return workerLevels[len(workerLevels)-1].workers
+	}
+
+	// Scale up: from level i to i+1, need numJobs > workerLevels[i].up
+	targetIdx := currentIdx
+	for i := currentIdx; i < len(workerLevels)-1 && numJobs > workerLevels[i].up; i++ {
+		targetIdx = i + 1
+	}
+	if targetIdx > currentIdx {
+		return workerLevels[targetIdx].workers
+	}
+
+	// Scale down: from level i to i-1, need numJobs < workerLevels[i-1].down
+	for i := currentIdx - 1; i >= 0 && numJobs < workerLevels[i].down; i-- {
+		targetIdx = i
+	}
+	if targetIdx < currentIdx {
+		return workerLevels[targetIdx].workers
+	}
+
+	// Stay at current level
+	return currentWorkers
+}
+
+func (wp *workerPool) runBatch(ctx context.Context, jobs []job) (map[common.Address]uint64, error) {
+	if len(jobs) == 0 {
+		return map[common.Address]uint64{}, nil
+	}
+
+	// Dynamically adjust worker count based on job count
+	wp.resize(len(jobs))
+
+	var cancel context.CancelFunc
+	wp.ctx, cancel = context.WithTimeout(wp.ctx, 20*time.Second)
+	defer cancel()
+	batchResultCh := make(chan result, len(jobs))
+	go func() {
+		for _, j := range jobs {
+			j.resultCh = batchResultCh
+			select {
+			case <-ctx.Done():
+				// return nil, ctx.Err()
+				return
+			case wp.jobs <- j:
+			}
+		}
+	}()
+	var firstErr error
+	res := make(map[common.Address]uint64)
+	refreshed := false
+	validatorSetChanged := true
+	retryCount := 0
+	batchResultCh2 := make(chan result, 10)
+	for i := 0; i < len(jobs); i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case r := <-batchResultCh:
+			// Check for errors and ensure we continue processing other results for successful jobs
+			if r.err != nil {
+				if firstErr == nil {
+					firstErr = r.err
+				}
+				// If there was an error for this item, do not add its amounts and proceed to next result
+				continue
+			}
+			for d, amt := range r.amounts {
+				if amt.Sign() <= 0 && validatorSetChanged {
+					if !refreshed {
+						updated, err := wp.scanner.refreshValidators()
+						if err != nil {
+							return nil, err
+						}
+						refreshed = true
+						validatorSetChanged = updated
+						if !validatorSetChanged {
+							res[d] = 0
+							continue
+						}
+					}
+					retryCount++
+					wp.jobs <- job{
+						kind:       jobKindFullScan,
+						delegators: []common.Address{d},
+						resultCh:   batchResultCh2,
+					}
+					continue
+				}
+				amt = amt.Div(amt, divisor)
+				if !amt.IsUint64() {
+					return nil, fmt.Errorf("total balance exceeds uint64 max for delegator %s: %s", d.Hex(), amt.String())
+				}
+				res[d] = amt.Uint64()
+			}
+		}
+	}
+	for retryCount > 0 {
+		select {
+		case <-ctx.Done():
+		case r := <-batchResultCh2:
+			if r.err != nil {
+				if firstErr == nil {
+					firstErr = r.err
+				}
+				continue
+			}
+			for d, amt := range r.amounts {
+				amt = amt.Div(amt, divisor)
+				if !amt.IsUint64() {
+					return nil, fmt.Errorf("total balance exceeds uint64 max for delegator %s: %s", d.Hex(), amt.String())
+				}
+				res[d] = amt.Uint64()
+			}
+		}
+	}
+	close(batchResultCh)
+	return res, firstErr
+}

--- a/fetcher/bsc/workers.go
+++ b/fetcher/bsc/workers.go
@@ -13,8 +13,7 @@ import (
 type jobKind int
 
 const (
-	jobKindBatchDelegators jobKind = iota
-	jobKindFullScan
+	jobKindBatchCapsules jobKind = iota
 
 // maxConcurrency = 256
 // // max concurrency set from config
@@ -36,16 +35,13 @@ var workerLevels = []workerLevel{
 }
 
 type scannerInf interface {
-	batchQueryCreditForDelegators(ctx context.Context, credit common.Address, delegators []common.Address, blockNumber *big.Int) (map[common.Address]*big.Int, error)
-	fullScan(ctx context.Context, delegator common.Address, blockNumber *big.Int) (creditAddr common.Address, pooledBNB, lockedBNB *big.Int, err error)
-	refreshValidators() (updated bool, err error)
+	batchQueryCapsules(ctx context.Context, capsules []common.Address, blockNumber *big.Int) (map[common.Address]*big.Int, error)
 }
 
 type job struct {
 	kind       jobKind
 	block      uint64
-	credit     common.Address
-	delegators []common.Address
+	capsules   []common.Address
 	resultCh   chan result
 }
 
@@ -134,37 +130,12 @@ func (wp *workerPool) spawnWorker() {
 // handleJob processes a job in the worker goroutine
 func (wp *workerPool) handleJob(ctx context.Context, j job) result {
 	switch j.kind {
-	case jobKindBatchDelegators:
+	case jobKindBatchCapsules:
 		blockNumber := new(big.Int).SetUint64(j.block)
-		amounts, err := wp.scanner.batchQueryCreditForDelegators(ctx, j.credit, j.delegators, blockNumber)
+		amounts, err := wp.scanner.batchQueryCapsules(ctx, j.capsules, blockNumber)
 		return result{
 			amounts: amounts,
 			err:     err,
-		}
-	case jobKindFullScan:
-		if len(j.delegators) != 1 {
-			return result{err: errInvalidJob}
-		}
-		d := j.delegators[0]
-		blockNumber := new(big.Int).SetUint64(j.block)
-		_, pooledBNB, lockedBNB, err := wp.scanner.fullScan(ctx, d, blockNumber)
-		if err != nil {
-			if err == errNoValidatorFound {
-				return result{
-					amounts: map[common.Address]*big.Int{
-						d: big.NewInt(0),
-					},
-					err: nil,
-				}
-			}
-			return result{
-				err: err,
-			}
-		}
-		total := new(big.Int).Add(pooledBNB, lockedBNB)
-		return result{
-			amounts: map[common.Address]*big.Int{d: total},
-			err:     nil,
 		}
 	default:
 		return result{
@@ -288,10 +259,6 @@ func (wp *workerPool) runBatch(ctx context.Context, jobs []job) (map[common.Addr
 	}()
 	var firstErr error
 	res := make(map[common.Address]uint64)
-	refreshed := false
-	validatorSetChanged := true
-	retryCount := 0
-	batchResultCh2 := make(chan result, 10)
 	for i := 0; i < len(jobs); i++ {
 		select {
 		case <-ctx.Done():
@@ -306,46 +273,10 @@ func (wp *workerPool) runBatch(ctx context.Context, jobs []job) (map[common.Addr
 				continue
 			}
 			for d, amt := range r.amounts {
-				if amt.Sign() <= 0 && validatorSetChanged {
-					if !refreshed {
-						updated, err := wp.scanner.refreshValidators()
-						if err != nil {
-							return nil, err
-						}
-						refreshed = true
-						validatorSetChanged = updated
-						if !validatorSetChanged {
-							res[d] = 0
-							continue
-						}
-					}
-					retryCount++
-					wp.jobs <- job{
-						kind:       jobKindFullScan,
-						delegators: []common.Address{d},
-						resultCh:   batchResultCh2,
-					}
+				if amt == nil || amt.Sign() <= 0 {
+					res[d] = 0
 					continue
 				}
-				amt = amt.Div(amt, divisor)
-				if !amt.IsUint64() {
-					return nil, fmt.Errorf("total balance exceeds uint64 max for delegator %s: %s", d.Hex(), amt.String())
-				}
-				res[d] = amt.Uint64()
-			}
-		}
-	}
-	for retryCount > 0 {
-		select {
-		case <-ctx.Done():
-		case r := <-batchResultCh2:
-			if r.err != nil {
-				if firstErr == nil {
-					firstErr = r.err
-				}
-				continue
-			}
-			for d, amt := range r.amounts {
 				amt = amt.Div(amt, divisor)
 				if !amt.IsUint64() {
 					return nil, fmt.Errorf("total balance exceeds uint64 max for delegator %s: %s", d.Hex(), amt.String())

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -235,10 +235,12 @@ func (f *Fetcher) Start() error {
 					s, ok := f.sources[req.sourceName]
 					if !ok {
 						f.logger.Error("failed to set NST stakers for a nonexistent source", "source", req.sourceName)
+						continue
 					}
 					sNST, ok := s.(types.SourceNSTInf)
 					if !ok {
 						f.logger.Error("failed to set NST stakers for a source which doesn't support NST stakers", "source", req.sourceName)
+						continue
 					}
 					sNST.SetNSTStakers(req.sInfos, req.version, req.withdrawVersion)
 				}

--- a/fetcher/nst/types/types.go
+++ b/fetcher/nst/types/types.go
@@ -1,10 +1,9 @@
-package nst
+package types
 
 import (
 	"os"
 	"path"
 
-	"github.com/imua-xyz/price-feeder/fetcher/types"
 	fetchertypes "github.com/imua-xyz/price-feeder/fetcher/types"
 	feedertypes "github.com/imua-xyz/price-feeder/types"
 	"gopkg.in/yaml.v2"
@@ -26,10 +25,27 @@ limitation of imuachainv1:
 **/
 
 type Source struct {
-	Logger  feedertypes.LoggerInf
+	// Logger  feedertypes.LoggerInf
 	Stakers *fetchertypes.Stakers
-	*types.Source
+	*fetchertypes.Source
 }
+
+func NewSource(logger feedertypes.LoggerInf, name string, fetch fetchertypes.SourceFetchFunc, cfgPath string, reload fetchertypes.SourceReloadConfigFunc) *Source {
+	return &Source{
+		Stakers: fetchertypes.NewStakers(),
+		Source:  fetchertypes.NewSource(logger, name, fetch, cfgPath, reload),
+	}
+}
+
+func (s *Source) SetNSTStakers(sInfos fetchertypes.StakerInfos, version, withdrawVersion uint64) {
+	s.Stakers.Locker.Lock()
+	s.Stakers.SInfos = sInfos
+	s.Stakers.Version = version
+	s.Stakers.WithdrawVersion = withdrawVersion
+	s.Stakers.Locker.Unlock()
+}
+
+var _ fetchertypes.SourceNSTInf = &Source{}
 
 type Config struct {
 	URL   string `yaml:"url"`
@@ -46,18 +62,14 @@ const (
 	HexPrefix = "0x"
 )
 
-var (
-	Logger feedertypes.LoggerInf
-)
+var Logger feedertypes.LoggerInf
 
-func ParseConfig(confPath, envConf string) (Config, error) {
-	yamlFile, err := os.Open(path.Join(confPath, envConf))
+func ParseConfig[T any](confPath, envConf string) (cfg T, err error) {
+	var yamlFile *os.File
+	yamlFile, err = os.Open(path.Join(confPath, envConf))
 	if err != nil {
-		return Config{}, err
+		return
 	}
-	cfg := Config{}
-	if err = yaml.NewDecoder(yamlFile).Decode(&cfg); err != nil {
-		return Config{}, err
-	}
-	return cfg, nil
+	err = yaml.NewDecoder(yamlFile).Decode(&cfg)
+	return
 }

--- a/fetcher/solana/solana_fetch.go
+++ b/fetcher/solana/solana_fetch.go
@@ -36,7 +36,7 @@ func (s *source) fetch(token string) (*types.PriceInfo, error) {
 
 	// epoch not updated, just return without fetching since effective-balance has not changed
 	if epoch <= finalizedEpoch && version <= finalizedVersion {
-		s.Logger.Info("fetch active stake from solana, no change in epoch or version, return latestChangesBytes", "epoch", epoch, "version", version)
+		s.Logger().Info("fetch active stake from solana, no change in epoch or version, return latestChangesBytes", "epoch", epoch, "version", version)
 		return &types.PriceInfo{
 			Price: string(latestChangesBytes),
 			// combine epoch and version as roundID in priceInfo
@@ -44,20 +44,20 @@ func (s *source) fetch(token string) (*types.PriceInfo, error) {
 		}, nil
 	}
 
-	s.Logger.Info("fetch active stake from solana", "stakerList_length", len(sInfos), "epoch", epoch, "version", version)
-	changedStakerBalances, err := fetchStakerBalanceChanges(sInfos, startSlot, endSlot, s.Logger)
+	s.Logger().Info("fetch active stake from solana", "stakerList_length", len(sInfos), "epoch", epoch, "version", version)
+	changedStakerBalances, err := fetchStakerBalanceChanges(sInfos, startSlot, endSlot, s.Logger())
 	for err != nil {
 		if !errors.Is(err, errExceedsMaxSlot) {
 			return nil, err
 		}
-		s.Logger.Info("fetch active stake from solana, epoch increased during fetching, try latestEpoch, ", "prevEpoch", epoch, "version", version)
+		s.Logger().Info("fetch active stake from solana, epoch increased during fetching, try latestEpoch, ", "prevEpoch", epoch, "version", version)
 		epoch, startSlot, endSlot, _, err = getFinalizedEpoch()
 		if err != nil {
 			return nil, fmt.Errorf("fail to get finalized epoch from solana, error:%w", err)
 		}
 		// this should not happen
 		if epoch <= finalizedEpoch && version <= finalizedVersion {
-			s.Logger.Info("fetch active stake from solana, no change in epoch or version, return latestChangesBytes", "epoch", epoch, "version", version)
+			s.Logger().Info("fetch active stake from solana, no change in epoch or version, return latestChangesBytes", "epoch", epoch, "version", version)
 			return &types.PriceInfo{
 				Price: string(latestChangesBytes),
 				// combine epoch and version as roundID in priceInfo
@@ -65,12 +65,12 @@ func (s *source) fetch(token string) (*types.PriceInfo, error) {
 			}, nil
 		}
 
-		s.Logger.Info("retry fetching active stake from solana", "stakerList_length", len(sInfos), "epoch", epoch, "version", version)
-		changedStakerBalances, err = fetchStakerBalanceChanges(sInfos, startSlot, endSlot, s.Logger)
+		s.Logger().Info("retry fetching active stake from solana", "stakerList_length", len(sInfos), "epoch", epoch, "version", version)
+		changedStakerBalances, err = fetchStakerBalanceChanges(sInfos, startSlot, endSlot, s.Logger())
 	}
 
 	if len(changedStakerBalances) > 0 {
-		s.Logger.Info("fetch active stake from solana, some active stake of validators have changed")
+		s.Logger().Info("fetch active stake from solana, some active stake of validators have changed")
 		sort.Slice(changedStakerBalances, func(i, j int) bool {
 			return changedStakerBalances[i].StakerIndex < changedStakerBalances[j].StakerIndex
 		})

--- a/fetcher/solana/types.go
+++ b/fetcher/solana/types.go
@@ -4,23 +4,25 @@ import (
 	"fmt"
 	"strings"
 
-	nsttypes "github.com/imua-xyz/price-feeder/fetcher/nst"
+	nsttypes "github.com/imua-xyz/price-feeder/fetcher/nst/types"
 	"github.com/imua-xyz/price-feeder/fetcher/types"
+
+	// 	"github.com/imua-xyz/price-feeder/fetcher/types"
 	fetchertypes "github.com/imua-xyz/price-feeder/fetcher/types"
 	feedertypes "github.com/imua-xyz/price-feeder/types"
 )
 
 type source nsttypes.Source
 
-func (s *source) SetNSTStakers(sInfos fetchertypes.StakerInfos, version, withdrawVersion uint64) {
-	s.Stakers.Locker.Lock()
-	s.Stakers.SInfos = sInfos
-	s.Stakers.Version = version
-	s.Stakers.WithdrawVersion = withdrawVersion
-	s.Stakers.Locker.Unlock()
-}
+// func (s *source) SetNSTStakers(sInfos fetchertypes.StakerInfos, version, withdrawVersion uint64) {
+// 	s.Stakers.Locker.Lock()
+// 	s.Stakers.SInfos = sInfos
+// 	s.Stakers.Version = version
+// 	s.Stakers.WithdrawVersion = withdrawVersion
+// 	s.Stakers.Locker.Unlock()
+// }
 
-var _ fetchertypes.SourceNSTInf = &source{}
+// var _ fetchertypes.SourceNSTInf = &source{}
 
 const (
 	envConf   = "oracle_env_solana.yaml"
@@ -33,24 +35,24 @@ var (
 )
 
 func init() {
-	types.SourceInitializers[types.Solana] = initSolana
+	fetchertypes.SourceInitializers[fetchertypes.Solana] = initSolana
 }
 
-func initSolana(cfgPath string, l feedertypes.LoggerInf) (types.SourceInf, error) {
+func initSolana(cfgPath string, l feedertypes.LoggerInf) (fetchertypes.SourceInf, error) {
 	if logger = l; logger == nil {
 		if logger = feedertypes.GetLogger("fetcher_solana"); logger == nil {
 			return nil, feedertypes.ErrInitFail.Wrap("logger is not initialized")
 		}
 	}
 	// init from config file
-	cfg, err := nsttypes.ParseConfig(cfgPath, envConf)
+	cfg, err := nsttypes.ParseConfig[nsttypes.Config](cfgPath, envConf)
 	if err != nil {
 		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse config, error:%v", err))
 	}
 	urlEndpoint = cfg.URL
-	if err != nil {
-		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse url:%s, error:%v", cfg.URL, err))
-	}
+	//	if err != nil {
+	//		return nil, feedertypes.ErrInitFail.Wrap(fmt.Sprintf("failed to parse url:%s, error:%v", cfg.URL, err))
+	//	}
 
 	// parse nstID by splitting it with "_'"
 	nstID := strings.Split(cfg.NSTID, "_")
@@ -60,11 +62,12 @@ func initSolana(cfgPath string, l feedertypes.LoggerInf) (types.SourceInf, error
 
 	// init first to get a fixed pointer for 'fetch' to refer to
 	defaultSource = &source{}
-	*defaultSource = source{
-		Logger:  logger,
-		Source:  types.NewSource(logger, types.Solana, defaultSource.fetch, cfgPath, defaultSource.reload),
-		Stakers: types.NewStakers(),
-	}
+	*defaultSource = source(*(nsttypes.NewSource(logger, fetchertypes.Solana, defaultSource.fetch, cfgPath, defaultSource.reload)))
+	//	*defaultSource = source{
+	//		Logger:  logger,
+	//		Source:  types.NewSource(logger, types.Solana, defaultSource.fetch, cfgPath, defaultSource.reload),
+	//		Stakers: types.NewStakers(),
+	//	}
 
 	types.SetNativeAssetID(fetchertypes.NativeTokenSOL, cfg.NSTID)
 

--- a/fetcher/sources.go
+++ b/fetcher/sources.go
@@ -2,6 +2,7 @@ package fetcher
 
 import (
 	_ "github.com/imua-xyz/price-feeder/fetcher/beaconchain"
+	_ "github.com/imua-xyz/price-feeder/fetcher/bsc"
 	_ "github.com/imua-xyz/price-feeder/fetcher/chainlink"
 	_ "github.com/imua-xyz/price-feeder/fetcher/solana"
 )

--- a/fetcher/types/types.go
+++ b/fetcher/types/types.go
@@ -8,13 +8,12 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -124,6 +123,7 @@ func (p PriceInfo) EqualPrice(price PriceInfo) bool {
 	}
 	return false
 }
+
 func (p PriceInfo) EqualToBase64Price(price PriceInfo) bool {
 	if len(p.Price) < 32 {
 		return false
@@ -214,6 +214,7 @@ func newAddTokenReq(tokenName string) (*addTokenReq, chan *addTokenRes) {
 func (r *addTokenRes) Error() error {
 	return r.err
 }
+
 func (r *addTokenRes) Price() *PriceSync {
 	return r.price
 }
@@ -261,6 +262,10 @@ func NewSource(logger feedertypes.LoggerInf, name string, fetch SourceFetchFunc,
 		fetch:              fetch,
 		reload:             reload,
 	}
+}
+
+func (s *Source) Logger() feedertypes.LoggerInf {
+	return s.logger
 }
 
 // InitTokenNames adds the token names in the source's token list
@@ -455,10 +460,12 @@ const (
 	Chainlink    = "chainlink"
 	BaseCurrency = "usdt"
 	BeaconChain  = "beaconchain"
+	Bsc          = "bsc"
 	Solana       = "solana"
 
 	NativeTokenETH NSTToken = "nsteth"
 	NativeTokenSOL NSTToken = "nstsol"
+	NativeTokenBSC          = "nstbsc"
 
 	DefaultSlotsPerEpoch = uint64(32)
 )
@@ -477,11 +484,15 @@ var (
 	NSTTokens = map[NSTToken]struct{}{
 		NativeTokenETH: {},
 		NativeTokenSOL: {},
+		NativeTokenBSC: {},
 	}
+	// token -> assetID
 	NSTAssetIDMap = make(map[NSTToken]string)
-	NSTSourceMap  = map[NSTToken]string{
+	// token -> suource
+	NSTSourceMap = map[NSTToken]string{
 		NativeTokenETH: BeaconChain,
 		NativeTokenSOL: Solana,
+		NativeTokenBSC: Bsc,
 	}
 
 	Logger feedertypes.LoggerInf
@@ -962,7 +973,7 @@ func (s *Stakers) tryGrowVersionsFromCache(version, withdrawVersion uint64, upda
 	return nil
 }
 
-// GrowVersionsFromCacheByDeposit grows the staker infos from the cache to a specific version.
+// GrowVersionsFromCacheByDepositWithdraw grows the staker infos from the cache to a specific version.
 func (s *Stakers) GrowVersionsFromCacheByDepositWithdraw(version, withdrawVersion uint64) error {
 	if version < 1 {
 		return fmt.Errorf("version is less than 1, version:%d", version)

--- a/fetcher/types/types.go
+++ b/fetcher/types/types.go
@@ -313,7 +313,7 @@ func (s *Source) Start() map[string]*PriceSync {
 	// main routine of source, listen to:
 	// addToken to add a new token for the source and start fetching that token's price
 	// tokenNotConfigured to reload the source's config file for required token
-	// stop closes the source routines and set runnign status to false
+	// stop closes the source routines and set running status to false
 	go func() {
 		for {
 			select {

--- a/imuaclient/types.go
+++ b/imuaclient/types.go
@@ -379,6 +379,7 @@ func (s *SubscribeResult) getEventNSTStakers() (EventNSTStakers, error) {
 		if len(parsed) != 7 {
 			return nil, fmt.Errorf("failed to parse nstChange: expected 7 parts but got %d, nstChange: %s", len(parsed), nstChange)
 		}
+		// TODO: this should accept either 'deposit' or 'withdraw'
 		if parsed[0] != "deposit" {
 			return nil, fmt.Errorf("failed to parse nstChange: expected 'deposit' but got %s", parsed[0])
 		}

--- a/internal/feeder/feeder.go
+++ b/internal/feeder/feeder.go
@@ -190,7 +190,8 @@ func ResetNSTStakers(ec imuaclient.ImuaClientInf, assetID string, logger feedert
 			continue
 		}
 
-		if fetchertypes.NSTToken(feeder.token) == fetchertypes.NativeTokenETH {
+		switch fetchertypes.NSTToken(feeder.token) {
+		case fetchertypes.NativeTokenETH:
 			// beaconchain use hex validators index instead of validator pubkey
 			// TODO: do this conversion on imuachain side
 			for _, sInfo := range stakerInfos {
@@ -204,7 +205,26 @@ func ResetNSTStakers(ec imuaclient.ImuaClientInf, assetID string, logger feedert
 					}
 				}
 			}
+		// the ValidatorPubkey fieled used for the capsule address of bsc native restaking token, the string is jus the hex format of address
+		case fetchertypes.NativeTokenBSC:
+		default:
 		}
+
+		//		if fetchertypes.NSTToken(feeder.token) == fetchertypes.NativeTokenETH {
+		//			// beaconchain use hex validators index instead of validator pubkey
+		//			// TODO: do this conversion on imuachain side
+		//			for _, sInfo := range stakerInfos {
+		//				for i, validator := range sInfo.ValidatorList {
+		//					// TODO: error handling
+		//					validatorIdx, _ := fetchertypes.ConvertHexToIntStr(validator.ValidatorPubkey)
+		//					sInfo.ValidatorList[i] = &oracletypes.ValidatorDeposit{
+		//						ValidatorPubkey: validatorIdx,
+		//						Version:         validator.Version,
+		//						DepositAmount:   validator.DepositAmount,
+		//					}
+		//				}
+		//			}
+		//		}
 		if err := feeder.stakers.Reset(stakerInfos, version, all); err != nil {
 			logger.Error("failed to update stakers for native-restaking-token", "feederID", feeder.feederID, "token", feeder.token, "error", err)
 			count++

--- a/internal/feeder/types.go
+++ b/internal/feeder/types.go
@@ -106,11 +106,10 @@ func (lp *localPrice) updatePrice(p *updatePrice, twoPhases bool) (string, error
 	updatedPrice := *(p.price)
 	if twoPhases {
 		rootHash, err := base64.StdEncoding.DecodeString(p.price.Price)
-		rootHash = rootHash[:32]
 		if err != nil {
 			return "", fmt.Errorf("failed to parse rootHash from base64 price-string, price:%v, error:%w", p.price, err)
 		}
-		updatedPrice.Price = string(rootHash)
+		updatedPrice.Price = string(rootHash[:32])
 	}
 	lp.price = updatedPrice
 	lp.height = p.txHeight


### PR DESCRIPTION
- Add new BSC (Binance Smart Chain) fetcher with multicall support
- Reorganize NST types: move from fetcher/nst/types.go to fetcher/nst/types/
- Refactor beaconchain and solana fetchers
- Update shared types and sources registration